### PR TITLE
Pin Hadolint and restore PR validation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
     "assignees": ["scottgigawatt"],
     "reviewers": ["scottgigawatt"],
     "enabledManagers": [
+        "custom.regex",
         "docker-compose",
         "dockerfile",
         "git-submodules",
@@ -31,6 +32,18 @@
             "depNameTemplate": "alpine",
             "datasourceTemplate": "docker",
             "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^\\.pre-commit-config\\.ya?ml$/"
+            ],
+            "matchStrings": [
+                "entry:\\s+ghcr\\.io/hadolint/hadolint:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "depNameTemplate": "ghcr.io/hadolint/hadolint",
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
         }
     ],
     "packageRules": [
@@ -44,7 +57,7 @@
         },
         {
             "groupName": "Docker images",
-            "matchManagers": ["docker-compose", "dockerfile"]
+            "matchManagers": ["docker-compose", "dockerfile", "custom.regex"]
         },
         {
             "groupName": "Submodules",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,8 +90,12 @@ repos:
   #
   # Lint both project Dockerfiles against container image best practices.
   #
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.14.0
+  - repo: local
     hooks:
       - id: hadolint-docker
+        name: Lint Dockerfiles
+        description: Runs the digest-pinned Hadolint image against Dockerfiles
+        entry: ghcr.io/hadolint/hadolint:v2.15.1@sha256:32dac94127fd60b7b7e3fbfc65e1383b9b5e25c9bfd7b8536de7a539fe68a12d hadolint
+        language: docker_image
+        types: [dockerfile]
         args: ["--ignore", "DL3018"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,11 @@ ARG ALPINE_TAG=3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6e
 # Default install locations and image metadata that can be overridden using build args.
 #
 ARG PIA_BIN_HOME=/pia
+
+#
 # Privateerr includes "private", which Hadolint treats as secret-like.
 # This build argument contains only an install path.
+#
 # hadolint ignore=DL3064
 ARG PRIVATEERR_BIN_HOME=/privateerr
 ARG JQ_APK_REPOSITORY=https://dl-cdn.alpinelinux.org/alpine/edge/main
@@ -38,7 +41,10 @@ ARG IMAGE_VERSION=latest
 #
 # Set PIA scripts, Privateerr helper, and healthcheck locations.
 #
+
+#
 # This environment block publishes paths, not secrets.
+#
 # hadolint ignore=DL3064
 ENV PIA_BIN_HOME=${PIA_BIN_HOME} \
     PRIVATEERR_BIN_HOME=${PRIVATEERR_BIN_HOME} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,9 @@ ARG ALPINE_TAG=3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6e
 # Default install locations and image metadata that can be overridden using build args.
 #
 ARG PIA_BIN_HOME=/pia
+# Privateerr includes "private", which Hadolint treats as secret-like.
+# This build argument contains only an install path.
+# hadolint ignore=DL3064
 ARG PRIVATEERR_BIN_HOME=/privateerr
 ARG JQ_APK_REPOSITORY=https://dl-cdn.alpinelinux.org/alpine/edge/main
 ARG JQ_APK_MIN_VERSION=1.8.2-r0
@@ -35,6 +38,8 @@ ARG IMAGE_VERSION=latest
 #
 # Set PIA scripts, Privateerr helper, and healthcheck locations.
 #
+# This environment block publishes paths, not secrets.
+# hadolint ignore=DL3064
 ENV PIA_BIN_HOME=${PIA_BIN_HOME} \
     PRIVATEERR_BIN_HOME=${PRIVATEERR_BIN_HOME} \
     PRIVATEERR_HEALTHCHECK_MARKER=/healthcheck/privateerr.ready
@@ -90,7 +95,7 @@ WORKDIR ${PIA_BIN_HOME}
 #
 # Report healthy after the wrapper finishes generating the config and metadata.
 #
-HEALTHCHECK CMD test -f "${PRIVATEERR_HEALTHCHECK_MARKER}" || exit 1
+HEALTHCHECK CMD ["/bin/sh", "-c", "test -f \"${PRIVATEERR_HEALTHCHECK_MARKER}\""]
 
 #
 # Run the Privateerr wrapper as PID 1 so it receives Docker stop signals and


### PR DESCRIPTION
## Summary 🌈⚓

- replace Hadolint’s floating container invocation with v2.15.1 pinned by multi-architecture digest
- document narrowly scoped `DL3064` exceptions for Privateerr path variables
- use exec-form healthcheck syntax while preserving runtime marker expansion
- let Renovate detect and maintain the pinned Hadolint image through `custom.regex`

## Why this changed

Renovate PR #37 did not break the pipeline itself. The v2.14.0 pre-commit hook definition launched `ghcr.io/hadolint/hadolint` without a tag, so CI silently moved to v2.15.1 and began reporting two `DL3064` path-name false positives plus the shell-form healthcheck under `DL3025`.

This patch removes that floating dependency and makes future Hadolint changes explicit, reviewable dependency updates. Darling, the linting plank is now securely bolted down. ✨🏴‍☠️

## Validation

- `pre-commit run --all-files`
- `make help`
- `docker compose --env-file .env -f docker-compose.yml config --quiet`
- `make build`
- built-image healthcheck metadata inspection
- `make build-multiarch`
- `renovate-config-validator --strict .github/renovate.json5` using Renovate 44.3.2