### PR TITLE
Split Alpine Renovate matchers and link image registries

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,11 +22,21 @@
             "customType": "regex",
             "managerFilePatterns": [
                 "/(^|/)Dockerfile$/",
-                "/^\\.github/workflows/.*\\.ya?ml$/",
+                "/^\\.github/workflows/.*\\.ya?ml$/"
+            ],
+            "matchStrings": [
+                "ALPINE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "depNameTemplate": "alpine",
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
                 "/^example\\.env$/"
             ],
             "matchStrings": [
-                "ALPINE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
                 "ALPINE_TAG=\"\\$\\{ALPINE_TAG:-(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[a-f0-9]+)\\}\""
             ],
             "depNameTemplate": "alpine",

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The image builds from Alpine for a small footprint. Alpine is not a distro PIA l
 
 Published Privateerr images support `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
 
-Images are published to both GHCR and Docker Hub. Most users should stay on `latest`; use `edge` only when ye intentionally want the newest successful `main` build before it becomes a stable release.
+Images are published to both [GHCR](https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr) and [Docker Hub](https://hub.docker.com/repository/docker/scottgigawatt/privateerr/general). Most users should stay on `latest`; use `edge` only when ye intentionally want the newest successful `main` build before it becomes a stable release.
 
 | 📦 Registry | ✅ Stable                                  | 🧪 Edge                                 |
 | ----------- | ----------------------------------------- | --------------------------------------- |


### PR DESCRIPTION
## Summary 🌈⚓

- scope the generic Alpine tag matcher to Dockerfiles and GitHub Actions workflows
- give `example.env` its own shell-wrapper-aware Alpine matcher
- preserve every existing Alpine version, digest, and Hadolint setting
- link the README’s GHCR and Docker Hub names directly to their Privateerr package pages

## Why this changed

After `custom.regex` was enabled, both Alpine match expressions ran against `example.env`. The generic expression misread `${ALPINE_TAG:-3.24@sha256:…}` as the Docker version `"${ALPINE_TAG:-3.24`, while the wrapper-aware expression extracted the correct version and digest.

Renovate therefore reported a duplicate malformed dependency in Dependency Dashboard #26 and could not determine its next digest. Splitting the file scopes leaves one valid Alpine extraction from `example.env`, so the warning can finally walk the plank with impeccable posture. ✨🏴‍☠️

The README registry sentence now also takes readers straight to Privateerr on GHCR or Docker Hub instead of making them hunt for the published images.

## Validation

- Renovate 44.3.2 strict configuration validation
- Renovate 44.3.2 local lookup-only dependency extraction
- `pre-commit run --all-files`
- `test/check-alpine-tag-pins.sh`
- `docker compose --env-file example.env -f docker-compose.yml config --quiet`