### PR TITLE
🩹 Patch nghttp2 CVE-2026-58055

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,8 +32,9 @@ ARG PIA_BIN_HOME=/pia
 #
 # hadolint ignore=DL3064
 ARG PRIVATEERR_BIN_HOME=/privateerr
-ARG JQ_APK_REPOSITORY=https://dl-cdn.alpinelinux.org/alpine/edge/main
+ARG EDGE_APK_REPOSITORY=https://dl-cdn.alpinelinux.org/alpine/edge/main
 ARG JQ_APK_MIN_VERSION=1.8.2-r0
+ARG NGHTTP2_APK_MIN_VERSION=1.70.0-r0
 ARG IMAGE_CREATED=unknown
 ARG IMAGE_REVISION=unknown
 ARG IMAGE_VERSION=latest
@@ -78,7 +79,8 @@ COPY privateerr-date.sh /usr/local/bin/date
 
 #
 # Install the small runtime needed to generate PIA WireGuard configs.
-# jq comes from the configured repository until Alpine stable has the patched version.
+# jq and nghttp2-libs come from the configured edge repository until Alpine
+# stable has the required versions.
 #
 RUN apk add --no-cache \
       bash \
@@ -87,8 +89,9 @@ RUN apk add --no-cache \
       openresolv \
       wireguard-tools && \
     apk add --no-cache \
-      --repository="${JQ_APK_REPOSITORY}" \
-      "jq>=${JQ_APK_MIN_VERSION}" && \
+      --repository="${EDGE_APK_REPOSITORY}" \
+      "jq>=${JQ_APK_MIN_VERSION}" \
+      "nghttp2-libs>=${NGHTTP2_APK_MIN_VERSION}" && \
     chmod +x \
       "${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh" \
       /usr/local/bin/date


### PR DESCRIPTION
## 🏳️‍🌈 Executive summary

Privateerr currently receives `nghttp2-libs 1.69.0-r0` transitively through `curl` from Alpine 3.24, which Docker Scout flags for CVE-2026-58055. This patch keeps the production image on the pinned Alpine 3.24 base while selectively upgrading only `nghttp2-libs` to the fixed `1.70.0-r0` package from Alpine edge. Security barnacle, begone. 🌈⚓

## What changed

- rename the jq-specific edge repository argument to the reusable `EDGE_APK_REPOSITORY`
- add `NGHTTP2_APK_MIN_VERSION=1.70.0-r0`
- install the fixed `nghttp2-libs` package from the same narrowly scoped edge repository already used for jq

## Root cause and impact

Alpine 3.24 stable still provides `nghttp2-libs 1.69.0-r0`, so rebuilding the existing Dockerfile reproduces the scanner finding. The vulnerable `nghttpx` proxy executable is not installed in Privateerr, but the shared source-package version is still reported by scanners.

The change does not alter Privateerr configuration generation or runtime behavior. New images will contain the fixed library on every supported architecture and should clear the finding after registry analysis completes.

## Validation

- `make help`
- `make config`
- `make build`
- built-image inspection confirmed `nghttp2-libs-1.70.0-r0`, `curl-8.21.0-r0`, and `jq-1.8.2-r0`
- built-image inspection confirmed `nghttpx` remains absent
- `make build-multiarch` for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
- `pre-commit run --all-files`
- `git diff --check`

The local Docker Scout CLI could not perform a final database scan without a Docker Hub login; the installed fixed package version was verified directly in the built image instead.