### PR TITLE
🧭 Keep Privateerr's editors sailing in formation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,54 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# .editorconfig: Shared editor formatting rules for Privateerr-owned files.
+#
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[.github/workflows/*.{yml,yaml}]
+indent_style = space
+indent_size = 4
+
+[*.{json,json5}]
+indent_style = space
+indent_size = 4
+
+[.secrets.baseline]
+indent_style = space
+indent_size = 2
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[{Dockerfile,**/Dockerfile}]
+indent_style = space
+indent_size = 4
+
+[.gitmodules]
+indent_style = tab
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Executive treasure map ✨🏴‍☠️

This adds a root `.editorconfig` that turns Privateerr's existing formatting conventions into editor-native defaults, so future contributors get consistent files before the lint hooks ever need to intervene.

## What changed ⚓

- sets UTF-8, LF line endings, final newlines, and trailing-whitespace cleanup across the repository
- keeps ordinary YAML and Compose at two spaces while preserving the four-space GitHub Actions style
- matches four-space JSON/JSON5 and two-space detect-secrets baseline formatting
- standardizes shell scripts and Dockerfiles on four spaces
- preserves tab indentation for `Makefile` and `.gitmodules`
- keeps Markdown hard-break whitespace intact, matching the existing pre-commit policy

## Maintainer impact 🌈

Editors with EditorConfig support will apply the repository's established conventions automatically. This is tooling-only: it does not reformat existing files or change build, runtime, VPN, Compose, or workflow behavior.

## Validation voyage 🧪

- `pre-commit run --all-files`
- commit-time pre-commit hooks
- `git diff --check origin/main...HEAD`
- confirmed the branch is one clean commit containing only `.editorconfig`
