### PR TITLE
🏴‍☠️ Run container healthchecks without shell wrappers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,8 @@ services:
     healthcheck:
       <<: *default-healthcheck-settings  # Pull in default healthcheck settings
       test:                              # Healthy when healthcheck marker file exists
-        - CMD-SHELL
-        - test -f "$${PRIVATEERR_HEALTHCHECK_MARKER}"
+        - CMD
+        - privateerr-healthcheck
 
     # Mount host directories into the container
     volumes:
@@ -141,8 +141,12 @@ services:
     healthcheck:
       <<: *default-healthcheck-settings  # Pull in default healthcheck settings
       test:                              # Check Gluetun's internal health server
-        - CMD-SHELL
-        - wget -q -O /dev/null "http://127.0.0.1:9999" || exit 1
+        - CMD
+        - wget
+        - -q
+        - -O
+        - /dev/null
+        - http://127.0.0.1:9999
 
     # Specify container service dependencies
     depends_on:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,6 +75,7 @@ COPY LICENSE /LICENSE
 COPY pia-manual-connections/LICENSE /licenses/pia-manual-connections/LICENSE
 COPY pia-manual-connections ${PIA_BIN_HOME}
 COPY privateerr-entrypoint.sh ${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh
+COPY privateerr-healthcheck.sh /usr/local/bin/privateerr-healthcheck
 COPY privateerr-date.sh /usr/local/bin/date
 
 #
@@ -94,6 +95,7 @@ RUN apk add --no-cache \
       "nghttp2-libs>=${NGHTTP2_APK_MIN_VERSION}" && \
     chmod +x \
       "${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh" \
+      /usr/local/bin/privateerr-healthcheck \
       /usr/local/bin/date
 
 #
@@ -104,7 +106,7 @@ WORKDIR ${PIA_BIN_HOME}
 #
 # Report healthy after the wrapper finishes generating the config and metadata.
 #
-HEALTHCHECK CMD ["/bin/sh", "-c", "test -f \"${PRIVATEERR_HEALTHCHECK_MARKER}\""]
+HEALTHCHECK CMD ["privateerr-healthcheck"]
 
 #
 # Run the Privateerr wrapper as PID 1 so it receives Docker stop signals and

--- a/docker/privateerr-healthcheck.sh
+++ b/docker/privateerr-healthcheck.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# privateerr-healthcheck.sh: Report whether Privateerr generated its output successfully.
+#
+
+: "${PRIVATEERR_HEALTHCHECK_MARKER:=/healthcheck/privateerr.ready}"
+
+test -f "${PRIVATEERR_HEALTHCHECK_MARKER}"


### PR DESCRIPTION
## Summary ✨

- switch the Privateerr and Gluetun Compose healthchecks from `CMD-SHELL` to direct `CMD` argument arrays
- let `wget` report Gluetun health through its native exit status instead of appending `|| exit 1`
- replace the image-level `/bin/sh -c` marker check with a directly invoked, POSIX Privateerr healthcheck command
- preserve `PRIVATEERR_HEALTHCHECK_MARKER` overrides without shell expansion in Docker healthcheck configuration

## Why 🧭

These checks each execute one command, so an extra shell layer is unnecessary. Direct exec form preserves the command's exit status, avoids redundant shell syntax, and makes the rendered healthcheck arguments explicit.

## Validation 🧪

- `pre-commit run --all-files`
- `make help`
- `make build`
- `docker compose --env-file example.env -f docker-compose.yml config --quiet`
- verified rendered Compose tests are direct `CMD` arrays
- verified built image metadata is `["CMD","privateerr-healthcheck"]`
- verified the healthcheck command exits `0` for an existing marker and `1` for a missing marker, both locally and in the built image
- `git diff --check`

## Live e2e note 🌊

`make test-e2e` was attempted, but Privateerr stopped during PIA authentication before either healthcheck could participate: the login response was not valid JSON and the upstream setup reported rejected credentials. `make test-down` then removed the stack and restored the checked-in example files successfully.