### PR TITLE
Standardize Make lifecycle and preserve volumes on down

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,8 @@
 - [ ] `make build-platforms` if image dependencies or build stages changed
 - [ ] `make test-e2e` if VPN behavior changed
 - [ ] Pinned action SHAs and Alpine digest defaults still move together
-- [ ] `make clean-test` or `make nuke` restored example config
+- [ ] `make clean-test` restored example config after any live test
+- [ ] Any `make nuke` validation used only disposable project resources
 - [ ] `git status --short` shows no generated config, logs, or other stray cargo
 
 ## Secrets check 🛡️

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -180,8 +180,11 @@
 
     //
     // Validate project AWK programs against the portable POSIX language mode.
+    // Disable compatibility diagnostics because version 0.1.0 misclassifies
+    // POSIX newline statement separators and output redirection as errors.
     //
     "awk.mode": "awk",
+    "awk.stylisticWarnings.compatibility": false,
     "awk.stylisticWarnings.missingSemicolon": false,
 
     //

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,9 @@ make print-env
 Run `make clean-test` after live e2e tests to stop containers and restore example files.
 `make clean` removes only disposable developer artifacts; it must never touch
 containers, volumes, images, `.env`, generated VPN state, or checked-in examples.
+`make down` preserves volumes and images. `make nuke` removes only this Compose
+project's Docker resources and repository-owned Buildx cache, restores examples,
+and preserves `.env`, `backups/`, and persistent bind-mounted config.
 
 ## GitHub Workflow Rules
 

--- a/Makefile
+++ b/Makefile
@@ -10,67 +10,105 @@
 #
 # Makefile target names.
 #
-ALL=all
-BACKUP=backup
-DOWN=down
-CLEAN=clean
-CLEAN_TEST=clean-test
-NUKE=nuke
 BUILD_DEPENDS=build-depends
 CHECK_ENV=check-env
 CHECK_PIA=check-pia
-BUILD=build
-BUILD_BUCCANEERR=build-buccaneerr
-BUILD_PLATFORMS=build-platforms
-RUN_PRIVATEERR=run-privateerr
-RESTORE_TEST_CONFIG=restore-test-config
-TEST=test
-TEST_MAKE_HELPERS=test-make-helpers
-TEST_WORKFLOWS=test-workflows
-TEST_E2E=test-e2e
+ALL=all
 UP=up
+DOWN=down
+PS=ps
+LOGS=logs
 CONFIG=config
 ENV=env
 PRINT_CONFIG=print-config
 PRINT_ENV=print-env
-PS=ps
-LOGS=logs
+BUILD=build
+BUILD_PLATFORMS=build-platforms
+TEST=test
+TEST_MAKE_HELPERS=test-make-helpers
+TEST_WORKFLOWS=test-workflows
+TEST_E2E=test-e2e
+BACKUP=backup
+RESTORE_TEST_CONFIG=restore-test-config
+CLEAN_TEST=clean-test
+CLEAN=clean
+NUKE=nuke
 HELP=help
+
+#
+# Privateerr-specific public target names.
+#
+BUILD_BUCCANEERR=build-buccaneerr
+RUN_PRIVATEERR=run-privateerr
+
+#
+# Internal prerequisite target names.
+#
+ENSURE_BUILDX_BUILDER=ensure-buildx-builder
+
+#
+# Compatibility alias target names.
+#
 START=start
 STOP=stop
 
 #
-# List of all available targets
+# Common public targets shared by Plundarr and Privateerr.
 #
-TARGETS= \
-	$(ALL) \
-	$(BACKUP) \
-	$(DOWN) \
-	$(CLEAN) \
-	$(CLEAN_TEST) \
-	$(NUKE) \
+COMMON_TARGETS= \
 	$(BUILD_DEPENDS) \
 	$(CHECK_ENV) \
 	$(CHECK_PIA) \
-	$(BUILD) \
-	$(BUILD_BUCCANEERR) \
-	$(BUILD_PLATFORMS) \
-	$(RUN_PRIVATEERR) \
-	$(RESTORE_TEST_CONFIG) \
-	$(TEST) \
-	$(TEST_MAKE_HELPERS) \
-	$(TEST_WORKFLOWS) \
-	$(TEST_E2E) \
+	$(ALL) \
 	$(UP) \
+	$(DOWN) \
+	$(PS) \
+	$(LOGS) \
 	$(CONFIG) \
 	$(ENV) \
 	$(PRINT_CONFIG) \
 	$(PRINT_ENV) \
-	$(PS) \
-	$(LOGS) \
-	$(HELP) \
+	$(BUILD) \
+	$(BUILD_PLATFORMS) \
+	$(TEST) \
+	$(TEST_MAKE_HELPERS) \
+	$(TEST_WORKFLOWS) \
+	$(TEST_E2E) \
+	$(BACKUP) \
+	$(RESTORE_TEST_CONFIG) \
+	$(CLEAN_TEST) \
+	$(CLEAN) \
+	$(NUKE) \
+	$(HELP)
+
+#
+# Public targets unique to this repository.
+#
+PROJECT_TARGETS= \
+	$(BUILD_BUCCANEERR) \
+	$(RUN_PRIVATEERR)
+
+#
+# Internal prerequisites and file targets.
+#
+INTERNAL_TARGETS= \
+	$(ENSURE_BUILDX_BUILDER)
+
+#
+# Compatibility aliases retained for existing callers.
+#
+ALIAS_TARGETS= \
 	$(START) \
 	$(STOP)
+
+#
+# Complete target inventory used by .PHONY.
+#
+TARGETS= \
+	$(COMMON_TARGETS) \
+	$(PROJECT_TARGETS) \
+	$(INTERNAL_TARGETS) \
+	$(ALIAS_TARGETS)
 
 #
 # Punctuation expanded after Make parses $(call ...) arguments.
@@ -93,7 +131,7 @@ PRIVATEERR_EXAMPLE_WG_CONFIG   ?= test/examples/example-wg0.conf
 PRIVATEERR_EXAMPLE_METADATA    ?= test/examples/example-privateerr.env
 PRIVATEERR_GENERATED_WG_CONFIG ?= config/gluetun/wireguard/wg0.conf
 PRIVATEERR_GENERATED_METADATA  ?= config/gluetun/wireguard/privateerr.env
-PRIVATEERR_GENERATED_PATHS     ?= config/privateerr/logs \
+RUNTIME_ARTIFACT_PATHS        := config/privateerr/logs \
 	config/buccaneerr/logs \
 	config/gluetun/forwarded_port \
 	config/gluetun/ip \
@@ -124,44 +162,34 @@ ORDER_ENVIRONMENT_AWK      ?= scripts/awk/order-environment.awk
 STRIP_COMMENTS_AWK         ?= scripts/awk/strip-comments.awk
 
 #
-# Extract base FROM images from Dockerfiles and resolve Dockerfile ARG defaults.
-#
-FROM_IMAGES ?= $(shell \
-	$(AWK_BIN) $(AWK_FILE_OPTION) $(DOCKERFILE_BASE_IMAGES_AWK) $(DOCKERFILES) \
-		| sort -u)
-
-#
-# Docker Compose command to list all images used by the stack, sorted and unique.
-#
-NUKE_COMPOSE_IMAGES_COMMAND ?= \
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) config --images 2>/dev/null | sort -u
-
-#
-# Docker container filter options used by the nuke target to identify containers to remove.
-#
-NUKE_CONTAINER_FILTER_OPTIONS ?= \
-	--filter "name=^/privateerr-" \
-	--filter "name=^/gluetun-" \
-	--filter "name=^/buccaneerr-"
-
-#
 # Docker Compose options.
 #
-COMPOSE_FILE          ?= docker-compose.yml
-COMPOSE_DOWN_TIMEOUT  ?= 30
-COMPOSE_ENV_FILE      ?= $(ENV_FILE)
-COMPOSE_DOWN_OPTIONS  ?= --timeout $(COMPOSE_DOWN_TIMEOUT) --volumes --remove-orphans
-COMPOSE_BUILD_OPTIONS ?= --pull --no-cache
-COMPOSE_UP_OPTIONS    ?= --build --force-recreate --pull always --remove-orphans
-COMPOSE_LOGS_OPTIONS  ?= --follow
+PRIVATEERR_COMPOSE_PROJECT_NAME ?= privateerr
+COMPOSE_FILE                    ?= docker-compose.yml
+COMPOSE_DOWN_TIMEOUT            ?= 30
+COMPOSE_ENV_FILE                ?= $(ENV_FILE)
+COMPOSE_DOWN_OPTIONS            ?= \
+	--timeout $(COMPOSE_DOWN_TIMEOUT) \
+	--remove-orphans
+COMPOSE_NUKE_OPTIONS            ?= \
+	--timeout $(COMPOSE_DOWN_TIMEOUT) \
+	--volumes \
+	--remove-orphans \
+	--rmi all
+COMPOSE_BUILD_OPTIONS           ?= --pull --no-cache
+COMPOSE_UP_OPTIONS              ?= --build --force-recreate --pull always --remove-orphans
+COMPOSE_LOGS_OPTIONS            ?= --follow
 
 #
 # Project-owned helpers used by Make and GitHub Actions.
 #
 PIA_CREDENTIAL_CHECK_CMD  ?= scripts/compose/check-pia-credentials.sh
 COMPOSE_STATUS_CMD        ?= scripts/compose/ps.sh
+COMPOSE_NUKE_CMD          ?= scripts/compose/nuke.sh
 CONFIG_BACKUP_CMD         ?= scripts/compose/backup.sh
 MAKE_HELPERS_TEST_CMD     ?= test/helpers/test-make-helpers.sh
+COMPOSE_NUKE_TEST_CMD     ?= test/helpers/test-compose-nuke.sh
+BASE_IMAGES_TEST_CMD      ?= test/helpers/test-dockerfile-base-images.sh
 WORKFLOW_HELPERS_TEST_CMD ?= test/helpers/test-workflow-helpers.sh
 POLICY_HELPERS_TEST_CMD   ?= test/helpers/test-policy-checks.sh
 BUILD_PIN_POLICY_TEST_CMD ?= test/policy/check-build-pin-policy.sh
@@ -201,6 +229,8 @@ COMPOSE_PRIVATEERR_ONLY_OPTIONS ?= \
 #
 BUILDX_PLATFORM_OPTIONS     ?= --platform linux/amd64,linux/arm64,linux/arm/v7
 BUILDX_BUILD_OPTIONS        ?= --pull --no-cache
+BUILDX_BUILDER_NAME         ?= privateerr-local
+BUILDX_BUILDER_DRIVER       ?= docker-container
 BUILDX_PRIVATEERR_IMAGE_TAG ?= ghcr.io/scottgigawatt/privateerr:multiarch-local
 BUILDX_BUCCANEERR_IMAGE_TAG ?= ghcr.io/scottgigawatt/buccaneerr:multiarch-local
 
@@ -216,6 +246,7 @@ DOCKER_BUILDX ?= $(DOCKER_BIN) buildx
 #
 BUILDX_BUILD = \
 	$(DOCKER_BUILDX) build \
+	--builder "$(BUILDX_BUILDER_NAME)" \
 	$(BUILDX_BUILD_OPTIONS) \
 	$(BUILDX_PLATFORM_OPTIONS)
 
@@ -242,6 +273,17 @@ DOCKER_COMPOSE := $(shell \
 	else \
 		echo ""; \
 	fi)
+
+#
+# Bind Compose and its implicit --build paths to the repository-owned builder.
+# Keep the project name explicit instead of deriving it from the checkout path.
+#
+PRIVATEERR_COMPOSE = \
+	BUILDX_BUILDER="$(BUILDX_BUILDER_NAME)" \
+	$(DOCKER_COMPOSE) \
+	--project-name "$(PRIVATEERR_COMPOSE_PROJECT_NAME)" \
+	--env-file "$(COMPOSE_ENV_FILE)" \
+	--file "$(COMPOSE_FILE)"
 
 #
 # Terminal presentation settings. Recipe-time checks enable color only for
@@ -344,15 +386,8 @@ EXAMPLE_ENV_FILE=example.env
 # Targets that are not files (i.e. never up-to-date); these will run every
 # time the target is called or required.
 #
+.DEFAULT_GOAL := $(ALL)
 .PHONY: $(TARGETS)
-
-#
-# $(ALL): Default makefile target. Builds and starts the service stack.
-#
-# Dependencies:
-#   $(UP) - Builds, recreates, and starts every service in the stack.
-#
-$(ALL): $(UP)
 
 #
 # $(BUILD_DEPENDS): Ensure build dependencies are installed.
@@ -390,167 +425,15 @@ $(CHECK_ENV):
 #   $(CHECK_ENV) - Ensure .env exists.
 #
 $(CHECK_PIA): $(BUILD_DEPENDS) $(CHECK_ENV)
-	@$(DOCKER_COMPOSE) --env-file $(COMPOSE_ENV_FILE) --file $(COMPOSE_FILE) \
-		config --environment | $(PIA_CREDENTIAL_CHECK_CMD)
+	@$(PRIVATEERR_COMPOSE) config --environment | $(PIA_CREDENTIAL_CHECK_CMD)
 
 #
-# $(DOWN): Stops containers and removes containers, networks, and volumes.
+# $(ALL): Default makefile target. Builds and starts the service stack.
 #
 # Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#   $(UP) - Builds, recreates, and starts every service in the stack.
 #
-$(DOWN): $(BUILD_DEPENDS) $(CHECK_ENV)
-	$(call announce,Droppin' anchor for the Privateerr test stack. ⚓)
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) down $(COMPOSE_DOWN_OPTIONS)
-
-#
-# $(BUILD): Builds only the Privateerr image.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
-#
-$(BUILD): $(BUILD_DEPENDS) $(CHECK_ENV)
-	$(call announce,Building the Privateerr image. ⚒️)
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) build $(COMPOSE_BUILD_OPTIONS) $(PRIVATEERR_SERVICE)
-
-#
-# $(BUILD_BUCCANEERR): Builds only the Buccaneerr image.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
-#
-$(BUILD_BUCCANEERR): $(BUILD_DEPENDS) $(CHECK_ENV)
-	$(call announce,Building the Buccaneerr image. 🔎)
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) build $(COMPOSE_BUILD_OPTIONS) $(BUCCANEERR_SERVICE)
-
-#
-# $(BUILD_PLATFORMS): Verifies both images build for published architectures.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#
-$(BUILD_PLATFORMS): $(BUILD_DEPENDS)
-	$(call announce,Verifying builds for amd64$(COMMA) arm64$(COMMA) and arm/v7. 🧭)
-	$(PRIVATEERR_PLATFORM_BUILD)
-	$(BUCCANEERR_PLATFORM_BUILD)
-
-#
-# $(RUN_PRIVATEERR): Runs only Privateerr to generate WireGuard config and metadata.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_PIA) - Reject missing or example PIA credentials.
-#
-$(RUN_PRIVATEERR): $(CHECK_PIA)
-	$(call announce,Generating WireGuard config and Gluetun metadata. 📜)
-	PRIVATEERR_KEEPALIVE=false $(DOCKER_COMPOSE) --file $(COMPOSE_FILE) up \
-		$(COMPOSE_PRIVATEERR_ONLY_OPTIONS) \
-		$(PRIVATEERR_SERVICE)
-
-#
-# $(RESTORE_TEST_CONFIG): Restores checked-in example config files after live tests.
-#
-# Dependencies: None.
-#
-$(RESTORE_TEST_CONFIG):
-	$(call announce,Restoring example config files. 🧭)
-	cp $(PRIVATEERR_EXAMPLE_WG_CONFIG) $(PRIVATEERR_GENERATED_WG_CONFIG)
-	cp $(PRIVATEERR_EXAMPLE_METADATA) $(PRIVATEERR_GENERATED_METADATA)
-
-#
-# $(BACKUP): Archives the complete Privateerr config directory.
-#
-# Dependencies: None.
-#
-$(BACKUP):
-	@$(CONFIG_BACKUP_CMD) \
-		"$(CONFIG_PATH)" \
-		"$(CONFIG_BACKUP_PATH)" \
-		"$(CONFIG_BACKUP_NAME)"
-
-#
-# $(TEST_MAKE_HELPERS): Tests reusable Make and Compose helpers locally.
-#
-# Dependencies: None.
-#
-$(TEST_MAKE_HELPERS):
-	$(MAKE_HELPERS_TEST_CMD)
-
-#
-# $(TEST_WORKFLOWS): Tests workflow helpers and shared publishing policies
-#                    locally.
-#
-# Dependencies: None.
-#
-$(TEST_WORKFLOWS):
-	$(WORKFLOW_HELPERS_TEST_CMD)
-	$(BUILD_PIN_POLICY_TEST_CMD)
-	$(IMAGE_TAG_POLICY_TEST_CMD)
-	$(POLICY_HELPERS_TEST_CMD)
-
-#
-# $(TEST): Runs policy scripts and isolated automation-helper tests.
-#
-# Dependencies:
-#   $(TEST_MAKE_HELPERS) - Test reusable Make and Compose helpers.
-#   $(TEST_WORKFLOWS) - Test workflow payload and registry helpers.
-#
-$(TEST): $(TEST_MAKE_HELPERS) $(TEST_WORKFLOWS)
-	sh -n docker/privateerr-date.sh \
-		docker/privateerr-entrypoint.sh \
-		docker/privateerr-healthcheck.sh \
-		config/gluetun/scripts/gluetun-entrypoint-wrapper.sh \
-		test/buccaneerr-entrypoint.sh
-	$(call announce_success,Privateerr's local test voyage came back clean. ✅)
-
-#
-# $(TEST_E2E): Starts the full stack once and runs the Buccaneerr.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_PIA) - Reject missing or example PIA credentials.
-#
-$(TEST_E2E): $(CHECK_PIA)
-	$(call announce,Starting Privateerr$(COMMA) Gluetun$(COMMA) and Buccaneerr for e2e validation. 🌊)
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) up $(COMPOSE_TEST_OPTIONS)
-
-#
-# $(CLEAN_TEST): Stops and removes containers, then restores example config files.
-#
-# Dependencies:
-#   $(DOWN) - Stop and remove the stack.
-#   $(RESTORE_TEST_CONFIG) - Restore example config files.
-#
-$(CLEAN_TEST): $(DOWN) $(RESTORE_TEST_CONFIG)
-
-#
-# $(NUKE): Removes containers, local images, generated files, and resets example config.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
-#
-$(NUKE): $(BUILD_DEPENDS) $(CHECK_ENV)
-	$(call announce_warning,‼️ DANGER ‼️ Removing containers$(COMMA) images$(COMMA) logs$(COMMA) and generated state. 💣)
-	@compose_images="$$( $(NUKE_COMPOSE_IMAGES_COMMAND) || true )"; \
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) down $(COMPOSE_DOWN_OPTIONS) --rmi all; \
-	containers="$$($(DOCKER_BIN) ps --all --quiet $(NUKE_CONTAINER_FILTER_OPTIONS))"; \
-	if [ -n "$${containers}" ]; then \
-		echo "Removing leftover containers. 🧨"; \
-		$(DOCKER_BIN) rm --force $${containers}; \
-	fi; \
-	if [ -n "$${compose_images}" ]; then \
-		echo "Removing local service images."; \
-		$(DOCKER_BIN) image rm --force $${compose_images} >/dev/null 2>&1 || true; \
-	fi
-	@echo "Removing generated logs and Gluetun state. 🧽"
-	rm -rf $(PRIVATEERR_GENERATED_PATHS)
-	@echo "Removing base images used by Dockerfiles. ⚓"
-	$(DOCKER_BIN) image rm --force $(FROM_IMAGES) >/dev/null 2>&1 || true
-	@$(MAKE) --no-print-directory $(RESTORE_TEST_CONFIG)
+$(ALL): $(UP)
 
 #
 # $(UP): Builds, (re)creates, and starts every service in the stack.
@@ -559,49 +442,20 @@ $(NUKE): $(BUILD_DEPENDS) $(CHECK_ENV)
 #   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
 #   $(CHECK_PIA) - Reject missing or example PIA credentials.
 #
-$(UP): $(CHECK_PIA)
+$(UP): $(CHECK_PIA) $(ENSURE_BUILDX_BUILDER)
 	$(call announce,Building and starting the full service stack. 🚀)
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) up $(COMPOSE_UP_OPTIONS)
+	$(PRIVATEERR_COMPOSE) up $(COMPOSE_UP_OPTIONS)
 
 #
-# $(CONFIG): Renders the Docker Compose model.
+# $(DOWN): Stops containers and removes containers and networks.
 #
 # Dependencies:
 #   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
 #   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
 #
-$(CONFIG): $(BUILD_DEPENDS) $(CHECK_ENV)
-	$(DOCKER_COMPOSE) --env-file $(COMPOSE_ENV_FILE) --file $(COMPOSE_FILE) config
-
-#
-# $(ENV): Prints the evaluated docker compose default env configuration.
-#
-# Dependencies:
-#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
-#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
-#
-$(ENV): $(BUILD_DEPENDS) $(CHECK_ENV)
-	@$(DOCKER_COMPOSE) --env-file $(COMPOSE_ENV_FILE) --file $(COMPOSE_FILE) \
-		config --environment | \
-	$(AWK_BIN) $(AWK_ASSIGNMENT_OPTIONS) $(AWK_FILE_OPTION) \
-		$(ORDER_ENVIRONMENT_AWK) - $(COMPOSE_ENV_FILE)
-
-#
-# $(PRINT_CONFIG): Prints the raw uncommented docker compose yaml configuration.
-#
-# Dependencies: None.
-#
-$(PRINT_CONFIG):
-	@$(AWK_BIN) $(AWK_FILE_OPTION) $(STRIP_COMMENTS_AWK) $(COMPOSE_FILE)
-
-#
-# $(PRINT_ENV): Prints the raw uncommented docker compose env configuration.
-#
-# Dependencies:
-#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
-#
-$(PRINT_ENV): $(CHECK_ENV)
-	@$(AWK_BIN) $(AWK_FILE_OPTION) $(STRIP_COMMENTS_AWK) $(COMPOSE_ENV_FILE)
+$(DOWN): $(BUILD_DEPENDS) $(CHECK_ENV)
+	$(call announce,Droppin' anchor for the Privateerr test stack. ⚓)
+	$(PRIVATEERR_COMPOSE) down $(COMPOSE_DOWN_OPTIONS)
 
 #
 # $(PS): Displays the current Compose project in a compact status table.
@@ -624,42 +478,146 @@ $(PS): $(BUILD_DEPENDS) $(CHECK_ENV)
 #
 $(LOGS): $(CHECK_ENV)
 	$(call announce,Showing service stack logs. 🔎)
-	$(DOCKER_COMPOSE) --file $(COMPOSE_FILE) logs $(COMPOSE_LOGS_OPTIONS)
+	$(PRIVATEERR_COMPOSE) logs $(COMPOSE_LOGS_OPTIONS)
 
 #
-# $(HELP): Print help information.
+# $(CONFIG): Renders the Docker Compose model.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#
+$(CONFIG): $(BUILD_DEPENDS) $(CHECK_ENV)
+	$(PRIVATEERR_COMPOSE) config
+
+#
+# $(ENV): Prints the evaluated docker compose default env configuration.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#
+$(ENV): $(BUILD_DEPENDS) $(CHECK_ENV)
+	@$(PRIVATEERR_COMPOSE) config --environment | \
+	$(AWK_BIN) $(AWK_ASSIGNMENT_OPTIONS) $(AWK_FILE_OPTION) \
+		$(ORDER_ENVIRONMENT_AWK) - $(COMPOSE_ENV_FILE)
+
+#
+# $(PRINT_CONFIG): Prints the raw uncommented docker compose yaml configuration.
 #
 # Dependencies: None.
 #
-$(HELP):
-	$(call announce_title,🏴‍☠️ Privateerr command chart)
-	$(call announce_detail,Usage: make <target>)
-	$(call help_heading,🚀 Run the stack)
-	$(call help_line,$(RUN_PRIVATEERR),Generate WireGuard config and Gluetun metadata.)
-	$(call help_line,$(UP),Build and start the complete validation stack.)
-	$(call help_line,$(DOWN),Stop and remove stack containers and volumes.)
-	$(call help_line,$(PS),Show a compact container status table.)
-	$(call help_line,$(LOGS),Follow stack logs.)
-	$(call help_heading,🔎 Inspect configuration)
-	$(call help_line,$(CONFIG),Print Docker Compose's rendered configuration.)
-	$(call help_line,$(ENV),Print resolved Compose environment values.)
-	$(call help_line,$(PRINT_CONFIG),Print raw Compose configuration without comments.)
-	$(call help_line,$(PRINT_ENV),Print raw environment settings without comments.)
-	$(call help_heading,🧪 Test and build)
-	$(call help_line,$(TEST),Run policy and automation-helper tests.)
-	$(call help_line,$(TEST_MAKE_HELPERS),Test reusable Make and Compose helpers.)
-	$(call help_line,$(TEST_WORKFLOWS),Test workflow helpers and shared publishing policies.)
-	$(call help_line,$(TEST_E2E),Run the live Privateerr and Gluetun test.)
-	$(call help_line,$(BUILD),Build the Privateerr image.)
-	$(call help_line,$(BUILD_BUCCANEERR),Build the Buccaneerr test image.)
-	$(call help_line,$(BUILD_PLATFORMS),Check every published image architecture.)
-	$(call help_heading,🧹 Maintenance)
-	$(call help_line,$(BACKUP),Archive the complete config directory.)
-	$(call help_line,$(CLEAN),Remove only disposable developer artifacts.)
-	$(call help_line,$(CLEAN_TEST),Stop the stack and restore example test config.)
-	$(call help_line,$(RESTORE_TEST_CONFIG),Restore checked-in example VPN config.)
-	$(call help_line,$(NUKE),‼️ DANGER ‼️ remove containers$(COMMA) volumes$(COMMA) images$(COMMA) and generated state.)
-	$(call announce_warning,⚠️  Destructive targets never run automatically. Run make backup first.)
+$(PRINT_CONFIG):
+	@$(AWK_BIN) $(AWK_FILE_OPTION) $(STRIP_COMMENTS_AWK) $(COMPOSE_FILE)
+
+#
+# $(PRINT_ENV): Prints the raw uncommented docker compose env configuration.
+#
+# Dependencies:
+#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#
+$(PRINT_ENV): $(CHECK_ENV)
+	@$(AWK_BIN) $(AWK_FILE_OPTION) $(STRIP_COMMENTS_AWK) $(COMPOSE_ENV_FILE)
+
+#
+# $(BUILD): Builds only the Privateerr image.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#
+$(BUILD): $(BUILD_DEPENDS) $(CHECK_ENV) $(ENSURE_BUILDX_BUILDER)
+	$(call announce,Building the Privateerr image. ⚒️)
+	$(PRIVATEERR_COMPOSE) build $(COMPOSE_BUILD_OPTIONS) $(PRIVATEERR_SERVICE)
+
+#
+# $(BUILD_PLATFORMS): Verifies both images build for published architectures.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#
+$(BUILD_PLATFORMS): $(BUILD_DEPENDS) $(ENSURE_BUILDX_BUILDER)
+	$(call announce,Verifying builds for amd64$(COMMA) arm64$(COMMA) and arm/v7. 🧭)
+	$(PRIVATEERR_PLATFORM_BUILD)
+	$(BUCCANEERR_PLATFORM_BUILD)
+
+#
+# $(TEST): Runs policy scripts and isolated automation-helper tests.
+#
+# Dependencies:
+#   $(TEST_MAKE_HELPERS) - Test reusable Make and Compose helpers.
+#   $(TEST_WORKFLOWS) - Test workflow payload and registry helpers.
+#
+$(TEST): $(TEST_MAKE_HELPERS) $(TEST_WORKFLOWS)
+	sh -n docker/privateerr-date.sh \
+		docker/privateerr-entrypoint.sh \
+		docker/privateerr-healthcheck.sh \
+		config/gluetun/scripts/gluetun-entrypoint-wrapper.sh \
+		test/buccaneerr-entrypoint.sh
+	$(call announce_success,Privateerr's local test voyage came back clean. ✅)
+
+#
+# $(TEST_MAKE_HELPERS): Tests reusable Make and Compose helpers locally.
+#
+# Dependencies: None.
+#
+$(TEST_MAKE_HELPERS):
+	$(MAKE_HELPERS_TEST_CMD)
+	$(BASE_IMAGES_TEST_CMD)
+	$(COMPOSE_NUKE_TEST_CMD)
+
+#
+# $(TEST_WORKFLOWS): Tests workflow helpers and shared publishing policies
+#                    locally.
+#
+# Dependencies: None.
+#
+$(TEST_WORKFLOWS):
+	$(WORKFLOW_HELPERS_TEST_CMD)
+	$(BUILD_PIN_POLICY_TEST_CMD)
+	$(IMAGE_TAG_POLICY_TEST_CMD)
+	$(POLICY_HELPERS_TEST_CMD)
+
+#
+# $(TEST_E2E): Starts the full stack once and runs the Buccaneerr.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_PIA) - Reject missing or example PIA credentials.
+#
+$(TEST_E2E): $(CHECK_PIA) $(ENSURE_BUILDX_BUILDER)
+	$(call announce,Starting Privateerr$(COMMA) Gluetun$(COMMA) and Buccaneerr for e2e validation. 🌊)
+	$(PRIVATEERR_COMPOSE) up $(COMPOSE_TEST_OPTIONS)
+
+#
+# $(BACKUP): Archives the complete Privateerr config directory.
+#
+# Dependencies: None.
+#
+$(BACKUP):
+	@$(CONFIG_BACKUP_CMD) \
+		"$(CONFIG_PATH)" \
+		"$(CONFIG_BACKUP_PATH)" \
+		"$(CONFIG_BACKUP_NAME)"
+
+#
+# $(RESTORE_TEST_CONFIG): Restores checked-in example config files after live tests.
+#
+# Dependencies: None.
+#
+$(RESTORE_TEST_CONFIG):
+	$(call announce,Restoring example config files. 🧭)
+	cp $(PRIVATEERR_EXAMPLE_WG_CONFIG) $(PRIVATEERR_GENERATED_WG_CONFIG)
+	cp $(PRIVATEERR_EXAMPLE_METADATA) $(PRIVATEERR_GENERATED_METADATA)
+
+#
+# $(CLEAN_TEST): Stops and removes containers, then restores example config files.
+#
+# Dependencies:
+#   $(DOWN) - Stop and remove the stack.
+#   $(RESTORE_TEST_CONFIG) - Restore example config files.
+#
+$(CLEAN_TEST): $(DOWN) $(RESTORE_TEST_CONFIG)
 
 #
 # $(CLEAN): Removes only disposable developer artifacts.
@@ -672,6 +630,104 @@ $(CLEAN):
 	find "$(CLEAN_ARTIFACT_FIND_ROOT)" \
 		\( $(CLEAN_ARTIFACT_FIND_PRUNE) \) -prune -o \
 		\( $(CLEAN_ARTIFACT_FIND_MATCH) \) -exec rm -rf {} +
+
+#
+# $(NUKE): Removes project Docker resources and disposable runtime state.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#
+$(NUKE): $(BUILD_DEPENDS) $(CHECK_ENV)
+	$(call announce_warning,‼️ DANGER ‼️ Removing containers$(COMMA) volumes$(COMMA) images$(COMMA) scoped build cache$(COMMA) logs$(COMMA) and generated state. 💣)
+	$(COMPOSE_NUKE_CMD) \
+		--docker-bin "$(DOCKER_BIN)" \
+		--compose-file "$(COMPOSE_FILE)" \
+		--env-file "$(COMPOSE_ENV_FILE)" \
+		--project-name "$(PRIVATEERR_COMPOSE_PROJECT_NAME)" \
+		--down-timeout "$(COMPOSE_DOWN_TIMEOUT)" \
+		$(foreach dockerfile,$(DOCKERFILES),--dockerfile "$(dockerfile)") \
+		--base-image-awk "$(DOCKERFILE_BASE_IMAGES_AWK)" \
+		--builder-name "$(BUILDX_BUILDER_NAME)" \
+		--additional-image "$(BUILDX_PRIVATEERR_IMAGE_TAG)" \
+		--additional-image "$(BUILDX_BUCCANEERR_IMAGE_TAG)"
+	@$(MAKE) --no-print-directory $(CLEAN)
+	@echo "Removing generated logs and Gluetun state. 🧽"
+	rm -rf $(RUNTIME_ARTIFACT_PATHS)
+	@$(MAKE) --no-print-directory $(RESTORE_TEST_CONFIG)
+
+#
+# $(HELP): Print help information.
+#
+# Dependencies: None.
+#
+$(HELP):
+	$(call announce_title,🏴‍☠️ Privateerr command chart)
+	$(call announce_detail,Usage: make <target>)
+	$(call help_heading,🚀 Run the stack)
+	$(call help_line,$(UP),Build and start the complete validation stack.)
+	$(call help_line,$(DOWN),Stop the stack while preserving volumes and images.)
+	$(call help_line,$(PS),Show a compact container status table.)
+	$(call help_line,$(LOGS),Follow stack logs.)
+	$(call help_heading,🔎 Inspect configuration)
+	$(call help_line,$(CONFIG),Print Docker Compose's rendered configuration.)
+	$(call help_line,$(ENV),Print resolved Compose environment values.)
+	$(call help_line,$(PRINT_CONFIG),Print raw Compose configuration without comments.)
+	$(call help_line,$(PRINT_ENV),Print raw environment settings without comments.)
+	$(call help_heading,🧪 Build and test)
+	$(call help_line,$(BUILD),Build the Privateerr image.)
+	$(call help_line,$(BUILD_PLATFORMS),Check every published image architecture.)
+	$(call help_line,$(TEST),Run policy and automation-helper tests.)
+	$(call help_line,$(TEST_MAKE_HELPERS),Test reusable Make and Compose helpers.)
+	$(call help_line,$(TEST_WORKFLOWS),Test workflow helpers and shared publishing policies.)
+	$(call help_line,$(TEST_E2E),Run the live Privateerr and Gluetun test.)
+	$(call help_heading,🧹 Maintenance)
+	$(call help_line,$(BACKUP),Archive the complete config directory.)
+	$(call help_line,$(RESTORE_TEST_CONFIG),Restore checked-in example VPN config.)
+	$(call help_line,$(CLEAN_TEST),Stop the stack and restore example test config.)
+	$(call help_line,$(CLEAN),Remove only disposable developer artifacts.)
+	$(call help_line,$(NUKE),‼️ DANGER ‼️ remove project Docker resources and transient state.)
+	$(call help_heading,🧭 Privateerr tools)
+	$(call help_line,$(RUN_PRIVATEERR),Generate WireGuard config and Gluetun metadata.)
+	$(call help_line,$(BUILD_BUCCANEERR),Build the Buccaneerr test image.)
+	$(call announce_warning,⚠️  Destructive targets never run automatically. Run make backup first.)
+
+#
+# $(BUILD_BUCCANEERR): Builds only the Buccaneerr image.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_ENV) - Ensure .env exists before running Compose commands.
+#
+$(BUILD_BUCCANEERR): $(BUILD_DEPENDS) $(CHECK_ENV) $(ENSURE_BUILDX_BUILDER)
+	$(call announce,Building the Buccaneerr image. 🔎)
+	$(PRIVATEERR_COMPOSE) build $(COMPOSE_BUILD_OPTIONS) $(BUCCANEERR_SERVICE)
+
+#
+# $(RUN_PRIVATEERR): Runs only Privateerr to generate WireGuard config and metadata.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure build dependencies are installed.
+#   $(CHECK_PIA) - Reject missing or example PIA credentials.
+#
+$(RUN_PRIVATEERR): $(CHECK_PIA) $(ENSURE_BUILDX_BUILDER)
+	$(call announce,Generating WireGuard config and Gluetun metadata. 📜)
+	PRIVATEERR_KEEPALIVE=false $(PRIVATEERR_COMPOSE) up \
+		$(COMPOSE_PRIVATEERR_ONLY_OPTIONS) \
+		$(PRIVATEERR_SERVICE)
+
+#
+# $(ENSURE_BUILDX_BUILDER): Create the repository-owned Buildx builder when missing.
+#
+# Dependencies:
+#   $(BUILD_DEPENDS) - Ensure Docker and Docker Compose are installed.
+#
+$(ENSURE_BUILDX_BUILDER): $(BUILD_DEPENDS)
+	@if ! $(DOCKER_BUILDX) inspect "$(BUILDX_BUILDER_NAME)" >/dev/null 2>&1; then \
+		$(DOCKER_BUILDX) create \
+			--name "$(BUILDX_BUILDER_NAME)" \
+			--driver "$(BUILDX_BUILDER_DRIVER)" >/dev/null; \
+	fi
 
 #
 # $(START): Alias for $(UP).

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ PRIVATEERR_EXAMPLE_WG_CONFIG   ?= test/examples/example-wg0.conf
 PRIVATEERR_EXAMPLE_METADATA    ?= test/examples/example-privateerr.env
 PRIVATEERR_GENERATED_WG_CONFIG ?= config/gluetun/wireguard/wg0.conf
 PRIVATEERR_GENERATED_METADATA  ?= config/gluetun/wireguard/privateerr.env
-RUNTIME_ARTIFACT_PATHS        := config/privateerr/logs \
+RUNTIME_ARTIFACT_PATHS         := config/privateerr/logs \
 	config/buccaneerr/logs \
 	config/gluetun/forwarded_port \
 	config/gluetun/ip \
@@ -154,14 +154,8 @@ PRIVATEERR_COMPOSE_PROJECT_NAME ?= privateerr
 COMPOSE_FILE                    ?= docker-compose.yml
 COMPOSE_DOWN_TIMEOUT            ?= 30
 COMPOSE_ENV_FILE                ?= $(ENV_FILE)
-COMPOSE_DOWN_OPTIONS            ?= \
-	--timeout $(COMPOSE_DOWN_TIMEOUT) \
-	--remove-orphans
-COMPOSE_NUKE_OPTIONS            ?= \
-	--timeout $(COMPOSE_DOWN_TIMEOUT) \
-	--volumes \
-	--remove-orphans \
-	--rmi all
+COMPOSE_DOWN_OPTIONS            ?= --timeout $(COMPOSE_DOWN_TIMEOUT) --remove-orphans
+COMPOSE_NUKE_OPTIONS            ?= --timeout $(COMPOSE_DOWN_TIMEOUT) --volumes --remove-orphans --rmi all
 COMPOSE_BUILD_OPTIONS           ?= --pull --no-cache
 COMPOSE_UP_OPTIONS              ?= --build --force-recreate --pull always --remove-orphans
 COMPOSE_LOGS_OPTIONS            ?= --follow

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,6 @@ RUN_PRIVATEERR=run-privateerr
 ENSURE_BUILDX_BUILDER=ensure-buildx-builder
 
 #
-# Compatibility alias target names.
-#
-START=start
-STOP=stop
-
-#
 # Common public targets shared by Plundarr and Privateerr.
 #
 COMMON_TARGETS= \
@@ -95,20 +89,12 @@ INTERNAL_TARGETS= \
 	$(ENSURE_BUILDX_BUILDER)
 
 #
-# Compatibility aliases retained for existing callers.
-#
-ALIAS_TARGETS= \
-	$(START) \
-	$(STOP)
-
-#
 # Complete target inventory used by .PHONY.
 #
 TARGETS= \
 	$(COMMON_TARGETS) \
 	$(PROJECT_TARGETS) \
-	$(INTERNAL_TARGETS) \
-	$(ALIAS_TARGETS)
+	$(INTERNAL_TARGETS)
 
 #
 # Punctuation expanded after Make parses $(call ...) arguments.
@@ -728,19 +714,3 @@ $(ENSURE_BUILDX_BUILDER): $(BUILD_DEPENDS)
 			--name "$(BUILDX_BUILDER_NAME)" \
 			--driver "$(BUILDX_BUILDER_DRIVER)" >/dev/null; \
 	fi
-
-#
-# $(START): Alias for $(UP).
-#
-# Dependencies:
-#   $(UP) - Builds, recreates, and starts every service in the stack.
-#
-$(START): $(UP)
-
-#
-# $(STOP): Alias for $(DOWN).
-#
-# Dependencies:
-#   $(DOWN) - Stop and remove the stack.
-#
-$(STOP): $(DOWN)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ make config
 | -------------------------- | ------------------------------------------------------- |
 | `make run-privateerr`      | You only want fresh `wg0.conf` and `privateerr.env`.    |
 | `make up`                  | You want the full Privateerr + Gluetun Compose stack.   |
-| `make down`                | You want to stop and remove the stack.                  |
+| `make down`                | You want to stop the stack but preserve volumes/images. |
 | `make ps`                  | You want a compact container status table.              |
 | `make logs`                | You want to inspect container output.                   |
 | `make backup`              | You want a recoverable archive of the config directory. |
@@ -213,6 +213,14 @@ make config
 | `make clean`               | You want to remove only disposable developer artifacts. |
 | `make clean-test`          | You want to stop tests and restore example config.      |
 | `make restore-test-config` | You want to restore only the checked-in examples.       |
+| `make nuke`                | You want to remove project Docker resources and transient state. |
+
+> [!CAUTION]
+> `make nuke` removes Privateerr's containers, networks, volumes, service and
+> local images, and repository-owned Buildx cache. It restores the checked-in
+> WireGuard examples but preserves `.env`, `backups/`, and the persistent
+> `config/` directory. Declared Dockerfile base images are removed only when
+> Docker reports that they are not shared or in use.
 
 > [!TIP]
 >

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,11 +81,13 @@ COPY privateerr-healthcheck.sh      /usr/local/bin/privateerr-healthcheck
 COPY privateerr-date.sh             /usr/local/bin/date
 
 #
-# Install the small runtime needed to generate PIA WireGuard configs.
-# jq and nghttp2-libs come from the configured edge repository until Alpine
-# stable has the required versions.
+# Upgrade the base OpenSSL runtime libraries to Alpine's current fixed release,
+# then install the small runtime needed to generate PIA WireGuard configs. jq
+# and nghttp2-libs come from the configured edge repository until Alpine stable
+# has the required versions.
 #
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache libcrypto3 libssl3 && \
+    apk add --no-cache \
         bash \
         ca-certificates \
         curl \

--- a/docs/ADVANCED_USAGE.md
+++ b/docs/ADVANCED_USAGE.md
@@ -145,8 +145,14 @@ before the PR can merge.
 | `make build-buccaneerr` | Build only the Buccaneerr validation image.                            |
 | `make build-platforms`  | Verify both images for every published architecture.                   |
 | `make logs`             | Show test stack logs.                                                  |
+| `make down`             | Stop containers and remove networks while preserving volumes/images.  |
 | `make clean`            | Remove only disposable local test and tool artifacts.                  |
 | `make clean-test`       | Stop the live test stack and restore checked-in examples.              |
+| `make nuke`             | Remove project Docker resources/cache and reset transient test state.  |
+
+`make nuke` preserves `.env`, `backups/`, and persistent bind-mounted config.
+Base-image removal is best-effort when another container or project still uses
+the same image.
 
 ## 📄 Generated Files
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,6 +49,12 @@ make clean-test
 pre-commit run --all-files
 ```
 
+`make down` preserves volumes and images. `make clean` never touches Docker,
+`.env`, generated WireGuard state, config, or backups. Use `make nuke` only for
+an intentionally destructive reset of this repository's Docker resources and
+scoped Buildx cache; it still preserves `.env`, `backups/`, and persistent
+config before restoring the checked-in examples.
+
 > [!IMPORTANT]
 >
 > 🧪 `make test-e2e` uses real PIA credentials from `.env`. That voyage should happen locally, not with secrets flung into random public waters.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,15 +14,17 @@ it against a live deployment.
 | 🧮 AWK     | [`awk/strip-comments.awk`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/awk/strip-comments.awk)                     | Remove comments and blank lines from raw configuration output      |
 | 🐳 Compose | [`compose/backup.sh`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/compose/backup.sh)                               | Archive Privateerr config without replacing an existing backup     |
 | 🐳 Compose | [`compose/check-pia-credentials.sh`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/compose/check-pia-credentials.sh) | Report missing or example PIA credentials before Privateerr starts |
+| 🐳 Compose | [`compose/nuke.sh`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/compose/nuke.sh)                               | Remove resources owned by one explicit Compose project             |
 | 🐳 Compose | [`compose/ps.sh`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/compose/ps.sh)                                       | Print a compact status table for the Privateerr Compose project    |
 
 ## AWK Programs 🧮
 
 ### `awk/collect-dockerfile-base-images.awk`
 
-Records Dockerfile `ARG` defaults and resolves them in each `FROM` instruction.
-The Makefile uses its unique output to identify local base images during the
-explicit destructive cleanup target.
+Records global Dockerfile `ARG` defaults, resolves `${NAME}` and `$NAME` in
+`FROM`, ignores internal stages and `scratch`, and resets state between input
+files. Unresolved references are skipped instead of being passed to Docker.
+The nuke helper uses its unique output for best-effort declared-base cleanup.
 
 ### `awk/format-compose-status.awk`
 
@@ -56,6 +58,19 @@ values. Invalid credentials produce a color-aware diagnostic with a corrective
 action; redirected output remains plain text and `NO_COLOR` disables terminal
 color. `make run-privateerr`, `make up`, and `make test-e2e` call it
 automatically.
+
+### `compose/nuke.sh`
+
+Validates the selected Compose model before deleting anything, captures service
+images, runs project-scoped teardown with volumes, orphans, and service images,
+then removes explicitly supplied local image references and one named Buildx
+builder. Repeated `--dockerfile` and `--additional-image` arguments avoid shell
+command evaluation. Declared base images are removed without force, so shared or
+in-use references are retained with a warning. Missing resources are harmless;
+unexpected Compose, Docker, or builder failures stop the helper.
+
+The helper never deletes repository files, `.env`, config, or backups. Make
+owns the later repository cleanup, transient-state reset, and example restore.
 
 ### `compose/ps.sh`
 

--- a/scripts/awk/collect-dockerfile-base-images.awk
+++ b/scripts/awk/collect-dockerfile-base-images.awk
@@ -3,30 +3,151 @@
 #
 # Licensed under the Apache License, Version 2.0.
 #
-# collect-dockerfile-base-images.awk: Resolve Dockerfile ARG defaults used by
-#                                     FROM instructions and print base images.
+# collect-dockerfile-base-images.awk: Resolve global Dockerfile ARG defaults
+#                                     used by FROM instructions and print each
+#                                     external base image once.
 #
 # Usage: awk -f scripts/awk/collect-dockerfile-base-images.awk <Dockerfiles>
 #
 
 #
-# Record build-argument defaults that a later FROM instruction may reference.
+# clear_array: Remove every entry from an associative array portably.
 #
-/^ARG / {
-  split($2, argument_parts, "=")
-  docker_arguments[argument_parts[1]] = argument_parts[2]
+# Parameters: values - Associative array to clear.
+#
+# Returns: Nothing.
+#
+function clear_array(values, key) {
+  for (key in values) {
+    delete values[key]
+  }
 }
 
 #
-# Resolve every known build argument in each base-image reference.
+# trim: Remove leading and trailing horizontal whitespace.
 #
-/^FROM / {
-  base_image = $2
+# Parameters: value - String to trim.
+#
+# Returns: The trimmed string.
+#
+function trim(value) {
+  sub(/^[[:space:]]+/, "", value)
+  sub(/[[:space:]]+$/, "", value)
+  return value
+}
 
-  # Substitute the Dockerfile's ${NAME} expression with its declared default.
-  for (argument_name in docker_arguments) {
-    gsub("\\$[{]" argument_name "[}]", docker_arguments[argument_name], base_image)
+#
+# resolve_arguments: Replace Dockerfile variable references with known global
+#                    ARG defaults.
+#
+# Parameters: value - FROM image token to resolve.
+#
+# Returns: The resolved token. Sets resolve_failed when a value is unavailable.
+#
+function resolve_arguments(value, output, position, character, closing, name, end) {
+  output = ""
+  resolve_failed = 0
+
+  for (position = 1; position <= length(value); position++) {
+    character = substr(value, position, 1)
+    if (character != "$") {
+      output = output character
+      continue
+    }
+
+    if (substr(value, position + 1, 1) == "{") {
+      closing = index(substr(value, position + 2), "}")
+      if (closing == 0) {
+        resolve_failed = 1
+        return value
+      }
+
+      name = substr(value, position + 2, closing - 1)
+      position += closing + 1
+    } else {
+      end = position + 1
+      while (end <= length(value) && substr(value, end, 1) ~ /[A-Za-z0-9_]/) {
+        end++
+      }
+
+      name = substr(value, position + 1, end - position - 1)
+      if (name == "") {
+        output = output character
+        continue
+      }
+      position = end - 1
+    }
+
+    if (!(name in docker_arguments)) {
+      resolve_failed = 1
+      return value
+    }
+    output = output docker_arguments[name]
   }
 
-  print base_image
+  return output
+}
+
+#
+# Reset Dockerfile-scoped ARG and stage state for each input file.
+#
+FNR == 1 {
+  clear_array(docker_arguments)
+  clear_array(build_stages)
+  first_from_seen = 0
+}
+
+{
+  instruction_line = trim($0)
+  if (instruction_line == "" || substr(instruction_line, 1, 1) == "#") {
+    next
+  }
+
+  field_count = split(instruction_line, instruction_fields, /[[:space:]]+/)
+  instruction = toupper(instruction_fields[1])
+
+  # Only ARG instructions before the first FROM can affect a FROM reference.
+  if (instruction == "ARG" && !first_from_seen) {
+    argument = substr(instruction_line, length(instruction_fields[1]) + 1)
+    argument = trim(argument)
+    equals = index(argument, "=")
+
+    if (equals == 0) {
+      delete docker_arguments[argument]
+    } else {
+      argument_name = trim(substr(argument, 1, equals - 1))
+      argument_value = trim(substr(argument, equals + 1))
+      docker_arguments[argument_name] = argument_value
+    }
+    next
+  }
+
+  if (instruction != "FROM") {
+    next
+  }
+
+  first_from_seen = 1
+  image_field = 2
+  while (image_field <= field_count && instruction_fields[image_field] ~ /^--/) {
+    image_field++
+  }
+  if (image_field > field_count) {
+    next
+  }
+
+  base_image = resolve_arguments(instruction_fields[image_field])
+  if (resolve_failed) {
+    next
+  }
+
+  normalized_image = tolower(base_image)
+  if (normalized_image != "scratch" && !(normalized_image in build_stages) && !(base_image in printed_images)) {
+    print base_image
+    printed_images[base_image] = 1
+  }
+
+  alias_field = image_field + 1
+  if (alias_field + 1 <= field_count && toupper(instruction_fields[alias_field]) == "AS") {
+    build_stages[tolower(instruction_fields[alias_field + 1])] = 1
+  }
 }

--- a/scripts/awk/collect-dockerfile-base-images.awk
+++ b/scripts/awk/collect-dockerfile-base-images.awk
@@ -14,10 +14,11 @@
 # clear_array: Remove every entry from an associative array portably.
 #
 # Parameters: values - Associative array to clear.
+#             key    - Function-local iteration key; callers must not supply it.
 #
 # Returns: Nothing.
 #
-function clear_array(values, key) {
+function clear_array(values,    key) {
   for (key in values) {
     delete values[key]
   }
@@ -40,11 +41,17 @@ function trim(value) {
 # resolve_arguments: Replace Dockerfile variable references with known global
 #                    ARG defaults.
 #
-# Parameters: value - FROM image token to resolve.
+# Parameters: value     - FROM image token to resolve.
+#             output    - Function-local resolved-token buffer.
+#             position  - Function-local cursor within value.
+#             character - Function-local character at position.
+#             closing   - Function-local offset of a closing brace.
+#             name      - Function-local Dockerfile ARG name.
+#             end       - Function-local end of an unbraced ARG name.
 #
 # Returns: The resolved token. Sets resolve_failed when a value is unavailable.
 #
-function resolve_arguments(value, output, position, character, closing, name, end) {
+function resolve_arguments(value,    output, position, character, closing, name, end) {
   output = ""
   resolve_failed = 0
 

--- a/scripts/compose/nuke.sh
+++ b/scripts/compose/nuke.sh
@@ -1,0 +1,374 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# nuke.sh: Remove Docker resources attributable to one Compose project while
+#          leaving repository files, bind-mounted config, and backups intact.
+#
+# Usage: scripts/compose/nuke.sh --docker-bin <path> --compose-mode <mode>
+#        --compose-file <path> --env-file <path> --down-timeout <seconds>
+#        [--compose-bin <path>] [--project-name <name>]
+#        [--dockerfile <path> ...] [--base-image-awk <path>]
+#        [--builder-name <name>] [--additional-image <reference> ...]
+#
+
+#
+# Parsed command options.
+#
+docker_bin="docker"
+compose_bin=""
+compose_mode=""
+compose_file=""
+env_file=""
+project_name=""
+down_timeout=""
+base_image_awk=""
+builder_name=""
+dockerfiles=""
+additional_images=""
+temporary_directory=""
+
+#
+# Fail on errors and unset variables.
+#
+set -eu
+
+#
+# cleanup: Remove the helper's temporary working directory.
+#
+# Parameters: None.
+#
+# Returns: Nothing.
+#
+cleanup() {
+    if [ -n "${temporary_directory}" ] && [ -d "${temporary_directory}" ]; then
+        rm -rf "${temporary_directory}"
+    fi
+}
+
+#
+# fail: Print a diagnostic and stop before further cleanup.
+#
+# Parameters: $1 - Diagnostic message.
+#
+# Returns: Exits with a failure status.
+#
+fail() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+#
+# append_value: Add one value to a newline-delimited option list.
+#
+# Parameters: $1 - Existing list.
+#             $2 - Value to append.
+#
+# Returns: Prints the updated list.
+#
+append_value() {
+    if [ -n "$1" ]; then
+        printf '%s\n%s' "$1" "$2"
+    else
+        printf '%s' "$2"
+    fi
+}
+
+#
+# require_command: Confirm a command name or executable path is available.
+#
+# Parameters: $1 - Command name or path.
+#
+# Returns: Exits with a diagnostic when the command is unavailable.
+#
+require_command() {
+    case "$1" in
+        */*)
+            [ -x "$1" ] || fail "Required command is not executable: $1"
+            ;;
+        *)
+            command -v "$1" >/dev/null 2>&1 \
+                || fail "Required command was not found: $1"
+            ;;
+    esac
+}
+
+#
+# compose_project: Run Docker Compose for the explicitly selected project.
+#
+# Parameters: $@ - Docker Compose subcommand and arguments.
+#
+# Returns: The Docker Compose exit status.
+#
+compose_project() {
+    if [ "${compose_mode}" = "plugin" ]; then
+        if [ -n "${project_name}" ]; then
+            "${docker_bin}" compose \
+                --project-name "${project_name}" \
+                --env-file "${env_file}" \
+                --file "${compose_file}" \
+                "$@"
+        else
+            "${docker_bin}" compose \
+                --env-file "${env_file}" \
+                --file "${compose_file}" \
+                "$@"
+        fi
+    else
+        if [ -n "${project_name}" ]; then
+            "${compose_bin}" \
+                --project-name "${project_name}" \
+                --env-file "${env_file}" \
+                --file "${compose_file}" \
+                "$@"
+        else
+            "${compose_bin}" \
+                --env-file "${env_file}" \
+                --file "${compose_file}" \
+                "$@"
+        fi
+    fi
+}
+
+#
+# image_ids: List local image IDs matching one reference.
+#
+# Parameters: $1 - Image reference.
+#
+# Returns: Prints matching image IDs or returns a Docker failure.
+#
+image_ids() {
+    "${docker_bin}" image ls --quiet --no-trunc "$1"
+}
+
+#
+# remove_owned_image: Remove a present service or explicitly owned local image.
+#
+# Parameters: $1 - Image reference.
+#
+# Returns: Succeeds when absent or removed; propagates real Docker failures.
+#
+remove_owned_image() {
+    owned_image_ids=$(image_ids "$1") \
+        || fail "Could not inspect local image reference: $1"
+    if [ -z "${owned_image_ids}" ]; then
+        return 0
+    fi
+
+    "${docker_bin}" image rm "$1" \
+        || fail "Could not remove project image reference: $1"
+}
+
+#
+# remove_base_image: Try to remove a declared base image without forcing it.
+#
+# Parameters: $1 - Base-image reference.
+#
+# Returns: Succeeds when absent or removed and warns when Docker retains it.
+#
+remove_base_image() {
+    base_image_ids=$(image_ids "$1") \
+        || fail "Could not inspect local base-image reference: $1"
+    if [ -z "${base_image_ids}" ]; then
+        return 0
+    fi
+
+    if ! "${docker_bin}" image rm "$1"; then
+        echo "Retaining shared or in-use base image: $1" >&2
+    fi
+}
+
+#
+# Parse named options without evaluating shell command strings.
+#
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --docker-bin)
+            [ "$#" -ge 2 ] || fail "Missing value for --docker-bin."
+            docker_bin=$2
+            shift 2
+            ;;
+        --compose-bin)
+            [ "$#" -ge 2 ] || fail "Missing value for --compose-bin."
+            compose_bin=$2
+            shift 2
+            ;;
+        --compose-mode)
+            [ "$#" -ge 2 ] || fail "Missing value for --compose-mode."
+            compose_mode=$2
+            shift 2
+            ;;
+        --compose-file)
+            [ "$#" -ge 2 ] || fail "Missing value for --compose-file."
+            compose_file=$2
+            shift 2
+            ;;
+        --env-file)
+            [ "$#" -ge 2 ] || fail "Missing value for --env-file."
+            env_file=$2
+            shift 2
+            ;;
+        --project-name)
+            [ "$#" -ge 2 ] || fail "Missing value for --project-name."
+            project_name=$2
+            shift 2
+            ;;
+        --down-timeout)
+            [ "$#" -ge 2 ] || fail "Missing value for --down-timeout."
+            down_timeout=$2
+            shift 2
+            ;;
+        --dockerfile)
+            [ "$#" -ge 2 ] || fail "Missing value for --dockerfile."
+            dockerfiles=$(append_value "${dockerfiles}" "$2")
+            shift 2
+            ;;
+        --base-image-awk)
+            [ "$#" -ge 2 ] || fail "Missing value for --base-image-awk."
+            base_image_awk=$2
+            shift 2
+            ;;
+        --builder-name)
+            [ "$#" -ge 2 ] || fail "Missing value for --builder-name."
+            builder_name=$2
+            shift 2
+            ;;
+        --additional-image)
+            [ "$#" -ge 2 ] || fail "Missing value for --additional-image."
+            additional_images=$(append_value "${additional_images}" "$2")
+            shift 2
+            ;;
+        *)
+            fail "Unknown option: $1"
+            ;;
+    esac
+done
+
+#
+# Validate every input before issuing a destructive command.
+#
+[ -n "${compose_file}" ] || fail "--compose-file is required."
+[ -n "${env_file}" ] || fail "--env-file is required."
+[ -n "${down_timeout}" ] || fail "--down-timeout is required."
+case "${down_timeout}" in
+    *[!0-9]*) fail "--down-timeout must be a non-negative integer." ;;
+esac
+[ -f "${compose_file}" ] || fail "Compose file does not exist: ${compose_file}"
+[ -f "${env_file}" ] || fail "Environment file does not exist: ${env_file}"
+require_command "${docker_bin}"
+require_command awk
+require_command grep
+require_command mktemp
+require_command sort
+
+case "${compose_mode}" in
+    plugin)
+        "${docker_bin}" compose version >/dev/null 2>&1 \
+            || fail "Docker Compose plugin is unavailable through ${docker_bin}."
+        ;;
+    standalone)
+        [ -n "${compose_bin}" ] || compose_bin="docker-compose"
+        require_command "${compose_bin}"
+        "${compose_bin}" version >/dev/null 2>&1 \
+            || fail "Standalone Docker Compose is unavailable through ${compose_bin}."
+        ;;
+    "")
+        if "${docker_bin}" compose version >/dev/null 2>&1; then
+            compose_mode="plugin"
+        elif command -v docker-compose >/dev/null 2>&1; then
+            compose_mode="standalone"
+            compose_bin="docker-compose"
+        else
+            fail "Neither the Docker Compose plugin nor docker-compose is available."
+        fi
+        ;;
+    *)
+        fail "--compose-mode must be plugin or standalone."
+        ;;
+esac
+
+if [ -n "${dockerfiles}" ]; then
+    [ -n "${base_image_awk}" ] \
+        || fail "--base-image-awk is required when --dockerfile is used."
+    [ -f "${base_image_awk}" ] \
+        || fail "Base-image AWK program does not exist: ${base_image_awk}"
+
+    while IFS= read -r dockerfile; do
+        [ -n "${dockerfile}" ] || continue
+        [ -f "${dockerfile}" ] || fail "Dockerfile does not exist: ${dockerfile}"
+    done <<EOF
+${dockerfiles}
+EOF
+fi
+
+#
+# Capture the resolved project model and every removal candidate before teardown.
+#
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/compose-nuke.XXXXXX")
+trap cleanup 0 1 2 15
+: >"${temporary_directory}/base-images.raw"
+project_description=${project_name:-selected environment project}
+
+compose_project config --quiet \
+    || fail "Docker Compose could not resolve ${project_description}."
+compose_project config --images \
+    >"${temporary_directory}/service-images.raw" \
+    || fail "Docker Compose could not list images for ${project_description}."
+sort -u "${temporary_directory}/service-images.raw" \
+    >"${temporary_directory}/service-images"
+
+if [ -n "${dockerfiles}" ]; then
+    while IFS= read -r dockerfile; do
+        [ -n "${dockerfile}" ] || continue
+        awk -f "${base_image_awk}" "${dockerfile}" \
+            >>"${temporary_directory}/base-images.raw"
+    done <<EOF
+${dockerfiles}
+EOF
+fi
+sort -u "${temporary_directory}/base-images.raw" \
+    >"${temporary_directory}/base-images"
+
+#
+# Remove the selected Compose project and its directly attributable resources.
+#
+compose_project down \
+    --timeout "${down_timeout}" \
+    --volumes \
+    --remove-orphans \
+    --rmi all \
+    || fail "Docker Compose could not remove ${project_description}."
+
+while IFS= read -r image_reference; do
+    [ -n "${image_reference}" ] || continue
+    remove_owned_image "${image_reference}"
+done <"${temporary_directory}/service-images"
+
+if [ -n "${additional_images}" ]; then
+    while IFS= read -r image_reference; do
+        [ -n "${image_reference}" ] || continue
+        remove_owned_image "${image_reference}"
+    done <<EOF
+${additional_images}
+EOF
+fi
+
+while IFS= read -r image_reference; do
+    [ -n "${image_reference}" ] || continue
+    remove_base_image "${image_reference}"
+done <"${temporary_directory}/base-images"
+
+if [ -n "${builder_name}" ]; then
+    "${docker_bin}" buildx ls --format '{{.Name}}' \
+        >"${temporary_directory}/builders" \
+        || fail "Could not list Docker Buildx builders."
+    if grep -F -x "${builder_name}" "${temporary_directory}/builders" >/dev/null; then
+        "${docker_bin}" buildx rm --force "${builder_name}" \
+            || fail "Could not remove Docker Buildx builder: ${builder_name}"
+    fi
+fi
+
+echo "Removed Docker resources for ${project_description}."

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -52,9 +52,11 @@ LABEL org.opencontainers.image.title="Buccaneerr" \
         org.opencontainers.image.base.name="docker.io/library/alpine:${ALPINE_TAG}"
 
 #
-# Install validation tools. These stay out of the production image.
+# Upgrade the base OpenSSL runtime libraries to Alpine's current fixed release,
+# then install validation tools. These stay out of the production image.
 #
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache libcrypto3 libssl3 && \
+    apk add --no-cache \
         bash \
         ca-certificates \
         curl

--- a/test/README.md
+++ b/test/README.md
@@ -6,6 +6,7 @@ The test tree keeps responsibilities separate:
 
 - `policy/` verifies repository-wide dependency and image-tag rules.
 - `helpers/` exercises Make and workflow helpers without external writes.
+- `runtime/` performs opt-in acceptance checks against isolated Docker resources.
 - `stubs/` supplies deterministic Docker and Skopeo stand-ins for those tests.
 - `examples/` stores the checked-in WireGuard and metadata examples restored after a live voyage.
 - the test-root `Dockerfile` and `buccaneerr-entrypoint.sh` remain the Buccaneerr build context.
@@ -21,6 +22,7 @@ The test tree keeps responsibilities separate:
 | 🧰 Helpers | [`helpers/test-make-helpers.sh`](helpers/test-make-helpers.sh)           | Test AWK, backup, credential, and Compose helpers offline           |
 | 🧰 Helpers | [`helpers/test-policy-checks.sh`](helpers/test-policy-checks.sh)         | Test valid and invalid publishing-policy fixtures offline           |
 | 🧰 Helpers | [`helpers/test-workflow-helpers.sh`](helpers/test-workflow-helpers.sh)   | Test release, Discord, and registry helper behavior offline         |
+| 🌊 Runtime | [`runtime/test-compose-cleanup-live.sh`](runtime/test-compose-cleanup-live.sh) | Verify isolated `down` and `nuke` ownership on a real Docker daemon |
 | 🎭 Stubs   | [`stubs/compose-docker-stub.sh`](stubs/compose-docker-stub.sh)           | Supply deterministic Docker output to Compose helper tests          |
 | 🎭 Stubs   | [`stubs/workflow-skopeo-stub.sh`](stubs/workflow-skopeo-stub.sh)         | Simulate registry inspection without network access                 |
 
@@ -43,6 +45,20 @@ The complete local target checks reusable AWK and Compose helpers, config
 backups, release tags, every structured Discord profile, registry mirroring,
 synchronized SHA-256 build pins, and canonical image-tag channels. Disposable
 negative fixtures prove that mismatched pins and unsafe tag rules are rejected.
+
+Run the opt-in live cleanup acceptance after changing Compose lifecycle or
+nuke behavior:
+
+> [!CAUTION]
+>
+> ```sh
+> test/runtime/test-compose-cleanup-live.sh
+> ```
+
+It creates uniquely named disposable projects and unrelated sentinels on the
+real Docker daemon. The test proves `down` preserves volumes and images, then
+proves `nuke` removes only its project resources and named builder. It never
+uses the repository `.env`, config, backups, or PIA credentials.
 
 ## What Buccaneerr Be 🦜
 
@@ -106,6 +122,11 @@ make clean-test
 make restore-test-config
 make nuke
 ```
+
+`clean-test` uses the volume-preserving `down` path and restores the examples.
+`nuke` additionally removes project containers, networks, volumes, images, and
+the `privateerr-local` Buildx cache, but it leaves `.env`, `backups/`, and the
+persistent config directory intact. Shared or in-use base images are retained.
 
 > [!TIP]
 >

--- a/test/helpers/test-compose-nuke.sh
+++ b/test/helpers/test-compose-nuke.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# test-compose-nuke.sh: Validate project-scoped destructive cleanup without
+#                       contacting the developer's Docker daemon.
+#
+# Usage: test/helpers/test-compose-nuke.sh
+#
+
+#
+# Directory for isolated nuke-helper fixtures.
+#
+test_output=""
+
+#
+# Fail on errors and unset variables.
+#
+set -eu
+
+#
+# cleanup: Remove the isolated nuke-helper test directory.
+#
+# Parameters: None.
+#
+# Returns: Nothing.
+#
+cleanup() {
+    if [ -n "${test_output}" ] && [ -d "${test_output}" ]; then
+        rm -rf "${test_output}"
+    fi
+}
+
+#
+# Create isolated project fixtures and register cleanup on exit.
+#
+test_output=$(mktemp -d)
+trap cleanup 0 1 2 15
+stub_path="$(pwd)/test/stubs/docker-nuke-stub.sh"
+: >"${test_output}/compose file.yml"
+: >"${test_output}/project.env"
+printf '%s\n' 'FROM test/shared-base:1' >"${test_output}/Dockerfile test"
+mkdir -p "${test_output}/config" "${test_output}/backups"
+printf '%s\n' 'preserve me' >"${test_output}/project.env.preserved"
+printf '%s\n' 'preserve me' >"${test_output}/config/state.db"
+printf '%s\n' 'preserve me' >"${test_output}/backups/config.tar.gz"
+
+#
+# Reject incomplete arguments before invoking Docker.
+#
+: >"${test_output}/missing.log"
+if NUKE_STUB_LOG="${test_output}/missing.log" \
+    sh scripts/compose/nuke.sh --docker-bin "${stub_path}" \
+        >"${test_output}/missing.out" 2>&1; then
+    echo "Compose nuke helper accepted incomplete arguments." >&2
+    exit 1
+fi
+grep -F -- '--compose-file is required.' "${test_output}/missing.out" >/dev/null
+test ! -s "${test_output}/missing.log"
+
+#
+# Remove one isolated project while retaining shared base images and host files.
+#
+: >"${test_output}/nuke.log"
+NUKE_STUB_LOG="${test_output}/nuke.log" \
+    sh scripts/compose/nuke.sh \
+        --docker-bin "${stub_path}" \
+        --compose-mode plugin \
+        --compose-file "${test_output}/compose file.yml" \
+        --env-file "${test_output}/project.env" \
+        --project-name test-project \
+        --down-timeout 45 \
+        --dockerfile "${test_output}/Dockerfile test" \
+        --base-image-awk scripts/awk/collect-dockerfile-base-images.awk \
+        --builder-name test-builder \
+        --additional-image test/additional:local \
+        >"${test_output}/nuke.out" 2>&1
+
+grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose file.yml config --quiet" \
+    "${test_output}/nuke.log" >/dev/null
+grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose file.yml config --images" \
+    "${test_output}/nuke.log" >/dev/null
+grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose file.yml down --timeout 45 --volumes --remove-orphans --rmi all" \
+    "${test_output}/nuke.log" >/dev/null
+grep -F 'image rm test/service:local' "${test_output}/nuke.log" >/dev/null
+grep -F 'image rm test/additional:local' "${test_output}/nuke.log" >/dev/null
+grep -F 'image rm test/shared-base:1' "${test_output}/nuke.log" >/dev/null
+grep -F "Retaining shared or in-use base image: test/shared-base:1" \
+    "${test_output}/nuke.out" >/dev/null
+grep -F 'buildx rm --force test-builder' "${test_output}/nuke.log" >/dev/null
+
+test "$(grep -c 'image rm test/service:local' "${test_output}/nuke.log")" -eq 1
+if grep -E 'system prune|image prune|volume prune|builder prune|--all-inactive|buildx rm --force unrelated-builder' \
+    "${test_output}/nuke.log" >/dev/null; then
+    echo "Compose nuke helper invoked a global or unrelated cleanup command." >&2
+    exit 1
+fi
+
+test -f "${test_output}/project.env"
+test -f "${test_output}/project.env.preserved"
+test -f "${test_output}/config/state.db"
+test -f "${test_output}/backups/config.tar.gz"
+
+#
+# Stop after an unexpected Compose failure without removing images or builders.
+#
+: >"${test_output}/failure.log"
+if NUKE_STUB_LOG="${test_output}/failure.log" NUKE_STUB_FAIL_COMPOSE=down \
+    sh scripts/compose/nuke.sh \
+        --docker-bin "${stub_path}" \
+        --compose-mode plugin \
+        --compose-file "${test_output}/compose file.yml" \
+        --env-file "${test_output}/project.env" \
+        --project-name test-project \
+        --down-timeout 45 \
+        --builder-name test-builder \
+        >"${test_output}/failure.out" 2>&1; then
+    echo "Compose nuke helper hid an unexpected teardown failure." >&2
+    exit 1
+fi
+grep -F 'Docker Compose could not remove test-project.' \
+    "${test_output}/failure.out" >/dev/null
+if grep -E 'image rm|buildx rm' "${test_output}/failure.log" >/dev/null; then
+    echo "Compose nuke helper continued after a teardown failure." >&2
+    exit 1
+fi
+
+echo "Compose nuke helper tests passed."

--- a/test/helpers/test-compose-nuke.sh
+++ b/test/helpers/test-compose-nuke.sh
@@ -40,9 +40,9 @@ cleanup() {
 test_output=$(mktemp -d)
 trap cleanup 0 1 2 15
 stub_path="$(pwd)/test/stubs/docker-nuke-stub.sh"
-: >"${test_output}/compose file.yml"
+: >"${test_output}/compose-file.yml"
 : >"${test_output}/project.env"
-printf '%s\n' 'FROM test/shared-base:1' >"${test_output}/Dockerfile test"
+printf '%s\n' 'FROM test/shared-base:1' >"${test_output}/Dockerfile.test"
 mkdir -p "${test_output}/config" "${test_output}/backups"
 printf '%s\n' 'preserve me' >"${test_output}/project.env.preserved"
 printf '%s\n' 'preserve me' >"${test_output}/config/state.db"
@@ -69,21 +69,21 @@ NUKE_STUB_LOG="${test_output}/nuke.log" \
     sh scripts/compose/nuke.sh \
         --docker-bin "${stub_path}" \
         --compose-mode plugin \
-        --compose-file "${test_output}/compose file.yml" \
+        --compose-file "${test_output}/compose-file.yml" \
         --env-file "${test_output}/project.env" \
         --project-name test-project \
         --down-timeout 45 \
-        --dockerfile "${test_output}/Dockerfile test" \
+        --dockerfile "${test_output}/Dockerfile.test" \
         --base-image-awk scripts/awk/collect-dockerfile-base-images.awk \
         --builder-name test-builder \
         --additional-image test/additional:local \
         >"${test_output}/nuke.out" 2>&1
 
-grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose file.yml config --quiet" \
+grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose-file.yml config --quiet" \
     "${test_output}/nuke.log" >/dev/null
-grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose file.yml config --images" \
+grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose-file.yml config --images" \
     "${test_output}/nuke.log" >/dev/null
-grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose file.yml down --timeout 45 --volumes --remove-orphans --rmi all" \
+grep -F "compose --project-name test-project --env-file ${test_output}/project.env --file ${test_output}/compose-file.yml down --timeout 45 --volumes --remove-orphans --rmi all" \
     "${test_output}/nuke.log" >/dev/null
 grep -F 'image rm test/service:local' "${test_output}/nuke.log" >/dev/null
 grep -F 'image rm test/additional:local' "${test_output}/nuke.log" >/dev/null
@@ -112,7 +112,7 @@ if NUKE_STUB_LOG="${test_output}/failure.log" NUKE_STUB_FAIL_COMPOSE=down \
     sh scripts/compose/nuke.sh \
         --docker-bin "${stub_path}" \
         --compose-mode plugin \
-        --compose-file "${test_output}/compose file.yml" \
+        --compose-file "${test_output}/compose-file.yml" \
         --env-file "${test_output}/project.env" \
         --project-name test-project \
         --down-timeout 45 \

--- a/test/helpers/test-dockerfile-base-images.sh
+++ b/test/helpers/test-dockerfile-base-images.sh
@@ -49,7 +49,7 @@ printf '%s\n' \
     'FROM build AS final' \
     'FROM scratch' \
     "FROM \${UNRESOLVED_IMAGE}" \
-    >"${test_output}/Dockerfile one"
+    >"${test_output}/Dockerfile.one"
 
 printf '%s\n' \
     'ARG BASE_IMAGE=alpine:3.24' \
@@ -57,7 +57,7 @@ printf '%s\n' \
     'FROM BASE' \
     'FROM alpine:3.24' \
     'FROM busybox:1.37' \
-    >"${test_output}/Dockerfile two"
+    >"${test_output}/Dockerfile.two"
 
 printf '%s\n' \
     'example.invalid/base@sha256:abc=def' \
@@ -66,8 +66,8 @@ printf '%s\n' \
     >"${test_output}/base-images.expected"
 
 awk -f scripts/awk/collect-dockerfile-base-images.awk \
-    "${test_output}/Dockerfile one" \
-    "${test_output}/Dockerfile two" \
+    "${test_output}/Dockerfile.one" \
+    "${test_output}/Dockerfile.two" \
     >"${test_output}/base-images.actual"
 
 cmp "${test_output}/base-images.expected" "${test_output}/base-images.actual"

--- a/test/helpers/test-dockerfile-base-images.sh
+++ b/test/helpers/test-dockerfile-base-images.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# test-dockerfile-base-images.sh: Validate portable Dockerfile base-image
+#                                 discovery without contacting Docker.
+#
+# Usage: test/helpers/test-dockerfile-base-images.sh
+#
+
+#
+# Directory for isolated parser fixtures.
+#
+test_output=""
+
+#
+# Fail on errors and unset variables.
+#
+set -eu
+
+#
+# cleanup: Remove the isolated parser-test directory.
+#
+# Parameters: None.
+#
+# Returns: Nothing.
+#
+cleanup() {
+    if [ -n "${test_output}" ] && [ -d "${test_output}" ]; then
+        rm -rf "${test_output}"
+    fi
+}
+
+#
+# Create isolated Dockerfile fixtures and register cleanup on exit.
+#
+test_output=$(mktemp -d)
+trap cleanup 0 1 2 15
+
+printf '%s\n' \
+    '# Global defaults may be referenced by FROM.' \
+    '  arg BASE_IMAGE=example.invalid/base@sha256:abc=def  ' \
+    'ARG BUILDPLATFORM=linux/amd64' \
+    "  from --platform=\${BUILDPLATFORM} \${BASE_IMAGE} AS Build  " \
+    'ARG STAGE_ONLY=example.invalid/not-a-base:latest' \
+    'FROM build AS final' \
+    'FROM scratch' \
+    "FROM \${UNRESOLVED_IMAGE}" \
+    >"${test_output}/Dockerfile one"
+
+printf '%s\n' \
+    'ARG BASE_IMAGE=alpine:3.24' \
+    "FROM \$BASE_IMAGE AS base" \
+    'FROM BASE' \
+    'FROM alpine:3.24' \
+    'FROM busybox:1.37' \
+    >"${test_output}/Dockerfile two"
+
+printf '%s\n' \
+    'example.invalid/base@sha256:abc=def' \
+    'alpine:3.24' \
+    'busybox:1.37' \
+    >"${test_output}/base-images.expected"
+
+awk -f scripts/awk/collect-dockerfile-base-images.awk \
+    "${test_output}/Dockerfile one" \
+    "${test_output}/Dockerfile two" \
+    >"${test_output}/base-images.actual"
+
+cmp "${test_output}/base-images.expected" "${test_output}/base-images.actual"
+
+echo "Dockerfile base-image tests passed."

--- a/test/helpers/test-make-helpers.sh
+++ b/test/helpers/test-make-helpers.sh
@@ -373,12 +373,6 @@ for target_group in COMMON_TARGETS PROJECT_TARGETS INTERNAL_TARGETS; do
     grep -F "${target_group}=" Makefile >/dev/null
 done
 
-if grep -E '^(ALIAS_TARGETS|RUN|START|STOP)=' Makefile >/dev/null \
-    || grep -E '^((run|start|stop)|\$\((RUN|START|STOP)\)):' Makefile >/dev/null; then
-    echo "The Makefile still defines compatibility alias targets." >&2
-    exit 1
-fi
-
 missing_dependency_comments=$(awk '
     /^# \$\(/ { target = $0; dependencies = 0; active = 1; next }
     active && /^# Dependencies/ { dependencies = 1 }

--- a/test/helpers/test-make-helpers.sh
+++ b/test/helpers/test-make-helpers.sh
@@ -77,7 +77,6 @@ printf '%s\n' \
     >"${test_output}/Dockerfile"
 printf '%s\n' \
     'alpine:3.23.3' \
-    'scratch' \
     >"${test_output}/base-images.expected"
 
 awk -f scripts/awk/collect-dockerfile-base-images.awk \
@@ -272,11 +271,45 @@ if grep -E '(^|[[:space:]])docker([[:space:]]|$)|\.env|wireguard|wg0\.conf|priva
 fi
 
 #
+# Keep ordinary down volume- and image-preserving.
+#
+NO_COLOR=1 make --dry-run down \
+    DOCKER_COMPOSE=true \
+    ENV_FILE=example.env \
+    COMPOSE_ENV_FILE=example.env \
+    >"${test_output}/down.out"
+grep -F 'down --timeout 30 --remove-orphans' "${test_output}/down.out" >/dev/null
+if grep -E 'down .*--volumes|down .*--rmi' "${test_output}/down.out" >/dev/null; then
+    echo "The down target includes destructive volume or image options." >&2
+    exit 1
+fi
+
+#
+# Delegate destructive Docker cleanup while invoking clean and restore once.
+#
+NO_COLOR=1 make --dry-run nuke \
+    DOCKER_COMPOSE=true \
+    ENV_FILE=example.env \
+    COMPOSE_ENV_FILE=example.env \
+    >"${test_output}/nuke.out"
+grep -F 'scripts/compose/nuke.sh' "${test_output}/nuke.out" >/dev/null
+grep -F -- '--project-name "privateerr"' "${test_output}/nuke.out" >/dev/null
+grep -F -- '--builder-name "privateerr-local"' "${test_output}/nuke.out" >/dev/null
+test "$(grep -c 'make --no-print-directory clean' "${test_output}/nuke.out")" -eq 1
+test "$(grep -c 'make --no-print-directory restore-test-config' "${test_output}/nuke.out")" -eq 1
+if grep -E 'docker (system|image|volume|builder) prune|--all-inactive|rm --force.*(service|base)' \
+    "${test_output}/nuke.out" >/dev/null; then
+    echo "The nuke target contains global or forceful image cleanup." >&2
+    exit 1
+fi
+
+#
 # Keep both platform-build recipes composed entirely from overridable variables.
 #
 NO_COLOR=1 make --dry-run build-platforms \
     DOCKER_COMPOSE=true \
     DOCKER_BUILDX=privateerr-buildx \
+    BUILDX_BUILDER_NAME=privateerr-test-builder \
     BUILDX_BUILD_OPTIONS=--test-build-option \
     BUILDX_PLATFORM_OPTIONS=--test-platform-option \
     BUILDX_PRIVATEERR_IMAGE_TAG=test/privateerr \
@@ -287,9 +320,9 @@ NO_COLOR=1 make --dry-run build-platforms \
     BUCCANEERR_BUILD_CONTEXT=test-buccaneerr-context \
     >"${test_output}/build-platforms.out"
 
-grep -F 'privateerr-buildx build --test-build-option --test-platform-option --tag "test/privateerr" --file "test-privateerr.Dockerfile" "test-privateerr-context"' \
+grep -F 'privateerr-buildx build --builder "privateerr-test-builder" --test-build-option --test-platform-option --tag "test/privateerr" --file "test-privateerr.Dockerfile" "test-privateerr-context"' \
     "${test_output}/build-platforms.out" >/dev/null
-grep -F 'privateerr-buildx build --test-build-option --test-platform-option --tag "test/buccaneerr" --file "test-buccaneerr.Dockerfile" "test-buccaneerr-context"' \
+grep -F 'privateerr-buildx build --builder "privateerr-test-builder" --test-build-option --test-platform-option --tag "test/buccaneerr" --file "test-buccaneerr.Dockerfile" "test-buccaneerr-context"' \
     "${test_output}/build-platforms.out" >/dev/null
 
 #
@@ -301,6 +334,56 @@ if LC_ALL=C grep "$(printf '\033')" "${test_output}/help.out" >/dev/null; then
     echo "Make help emitted terminal colors into redirected output." >&2
     exit 1
 fi
+
+#
+# Keep shared target groups and framed dependency comments reviewable.
+#
+common_targets=$(awk '
+    /^COMMON_TARGETS=/ { active = 1 }
+    active && match($0, /\$\([A-Z0-9_]+\)/) {
+        if (targets != "") {
+            targets = targets " "
+        }
+        targets = targets substr($0, RSTART + 2, RLENGTH - 3)
+    }
+    active && $0 !~ /\\$/ {
+        print targets
+        exit
+    }
+' Makefile)
+test "${common_targets}" = "BUILD_DEPENDS CHECK_ENV CHECK_PIA ALL UP DOWN PS LOGS CONFIG ENV PRINT_CONFIG PRINT_ENV BUILD BUILD_PLATFORMS TEST TEST_MAKE_HELPERS TEST_WORKFLOWS TEST_E2E BACKUP RESTORE_TEST_CONFIG CLEAN_TEST CLEAN NUKE HELP"
+common_recipe_order=$(awk '
+    /^\$\([A-Z0-9_]+\)(:| )/ {
+        target = $0
+        sub(/^\$\(/, "", target)
+        sub(/\).*/, "", target)
+        if (targets != "") {
+            targets = targets " "
+        }
+        targets = targets target
+        if (++count == 24) {
+            print targets
+            exit
+        }
+    }
+' Makefile)
+test "${common_recipe_order}" = "${common_targets}"
+grep -F ".DEFAULT_GOAL := \$(ALL)" Makefile >/dev/null
+for target_group in COMMON_TARGETS PROJECT_TARGETS INTERNAL_TARGETS ALIAS_TARGETS; do
+    grep -F "${target_group}=" Makefile >/dev/null
+done
+
+missing_dependency_comments=$(awk '
+    /^# \$\(/ { target = $0; dependencies = 0; active = 1; next }
+    active && /^# Dependencies/ { dependencies = 1 }
+    active && /^\$\(/ {
+        if (!dependencies) {
+            print target
+        }
+        active = 0
+    }
+' Makefile)
+test -z "${missing_dependency_comments}"
 
 #
 # Report success.

--- a/test/helpers/test-make-helpers.sh
+++ b/test/helpers/test-make-helpers.sh
@@ -369,9 +369,15 @@ common_recipe_order=$(awk '
 ' Makefile)
 test "${common_recipe_order}" = "${common_targets}"
 grep -F ".DEFAULT_GOAL := \$(ALL)" Makefile >/dev/null
-for target_group in COMMON_TARGETS PROJECT_TARGETS INTERNAL_TARGETS ALIAS_TARGETS; do
+for target_group in COMMON_TARGETS PROJECT_TARGETS INTERNAL_TARGETS; do
     grep -F "${target_group}=" Makefile >/dev/null
 done
+
+if grep -E '^(ALIAS_TARGETS|RUN|START|STOP)=' Makefile >/dev/null \
+    || grep -E '^((run|start|stop)|\$\((RUN|START|STOP)\)):' Makefile >/dev/null; then
+    echo "The Makefile still defines compatibility alias targets." >&2
+    exit 1
+fi
 
 missing_dependency_comments=$(awk '
     /^# \$\(/ { target = $0; dependencies = 0; active = 1; next }

--- a/test/runtime/test-compose-cleanup-live.sh
+++ b/test/runtime/test-compose-cleanup-live.sh
@@ -1,0 +1,318 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# test-compose-cleanup-live.sh: Verify down and nuke against isolated Docker
+#                               resources while unrelated sentinels survive.
+#
+# Purpose: Exercise the cleanup contract on a real Docker daemon without using
+#          a repository deployment, generated credentials, or persistent state.
+#
+# Usage: test/runtime/test-compose-cleanup-live.sh
+#
+
+#
+# Fail on errors and unset variables.
+#
+set -eu
+
+#
+# Resolve repository and disposable fixture paths.
+#
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPOSITORY_ROOT=$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)
+NUKE_HELPER="${REPOSITORY_ROOT}/scripts/compose/nuke.sh"
+TEMPORARY_DIRECTORY=$(mktemp -d "${TMPDIR:-/tmp}/compose-cleanup-live.XXXXXX")
+FIXTURE_DIRECTORY="${TEMPORARY_DIRECTORY}/fixture"
+PROTECTED_DIRECTORY="${TEMPORARY_DIRECTORY}/protected"
+COMPOSE_FILE="${FIXTURE_DIRECTORY}/docker-compose.yml"
+DOCKERFILE="${FIXTURE_DIRECTORY}/Dockerfile"
+ENV_FILE="${FIXTURE_DIRECTORY}/fixture.env"
+PROJECT_NAME="cleanup-live-$$"
+BUILDER_NAME="${PROJECT_NAME}-builder"
+SENTINEL_BUILDER_NAME="${PROJECT_NAME}-sentinel-builder"
+SERVICE_IMAGE="${PROJECT_NAME}-service:local"
+SENTINEL_IMAGE="${PROJECT_NAME}-sentinel:local"
+SENTINEL_CONTAINER="${PROJECT_NAME}-sentinel"
+SENTINEL_NETWORK="${PROJECT_NAME}-sentinel"
+SENTINEL_VOLUME="${PROJECT_NAME}-sentinel"
+PROJECT_VOLUME="${PROJECT_NAME}_fixture-data"
+ANONYMOUS_VOLUME=""
+SELECTED_BUILDER_BEFORE=""
+
+#
+# cleanup: Remove only resources carrying this test's unique names.
+#
+# Parameters: None.
+#
+# Returns: Nothing. Cleanup failures are ignored while preserving test status.
+#
+cleanup() {
+    docker compose \
+        --project-name "${PROJECT_NAME}" \
+        --env-file "${ENV_FILE}" \
+        --file "${COMPOSE_FILE}" \
+        down --timeout 5 --volumes --remove-orphans --rmi all \
+        >/dev/null 2>&1 || true
+    docker container rm --force "${SENTINEL_CONTAINER}" >/dev/null 2>&1 || true
+    docker network rm "${SENTINEL_NETWORK}" >/dev/null 2>&1 || true
+    docker volume rm "${SENTINEL_VOLUME}" >/dev/null 2>&1 || true
+    docker volume rm "${PROJECT_VOLUME}" >/dev/null 2>&1 || true
+    if [ -n "${ANONYMOUS_VOLUME}" ]; then
+        docker volume rm "${ANONYMOUS_VOLUME}" >/dev/null 2>&1 || true
+    fi
+    docker image rm "${SERVICE_IMAGE}" >/dev/null 2>&1 || true
+    docker image rm "${SENTINEL_IMAGE}" >/dev/null 2>&1 || true
+    docker buildx rm --force "${BUILDER_NAME}" >/dev/null 2>&1 || true
+    docker buildx rm --force "${SENTINEL_BUILDER_NAME}" >/dev/null 2>&1 || true
+    rm -rf "${TEMPORARY_DIRECTORY}"
+}
+
+#
+# fail: Print a diagnostic and stop the live acceptance test.
+#
+# Parameters: $1 - Diagnostic message.
+#
+# Returns: Exits with a failure status.
+#
+fail() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+#
+# assert_present: Require a resource inspection command to succeed.
+#
+# Parameters: $1 - Resource description.
+#             $@ - Inspection command and arguments.
+#
+# Returns: Exits when the resource is absent.
+#
+assert_present() {
+    description=$1
+    shift
+    "$@" >/dev/null 2>&1 || fail "Expected ${description} to remain."
+}
+
+#
+# assert_absent: Require a resource inspection command to fail.
+#
+# Parameters: $1 - Resource description.
+#             $@ - Inspection command and arguments.
+#
+# Returns: Exits when the resource is present.
+#
+assert_absent() {
+    description=$1
+    shift
+    if "$@" >/dev/null 2>&1; then
+        fail "Expected ${description} to be removed."
+    fi
+}
+
+#
+# selected_builder: Print the globally selected Buildx builder, if any.
+#
+# Parameters: None.
+#
+# Returns: Prints the selected builder name or an empty line.
+#
+selected_builder() {
+    docker buildx ls | awk '
+        $1 ~ /\*$/ {
+            sub(/\*$/, "", $1)
+            print $1
+            exit
+        }
+    '
+}
+
+#
+# builder_exists: Check whether one exact Buildx builder exists.
+#
+# Parameters: $1 - Builder name.
+#
+# Returns: Success when the builder exists, otherwise failure.
+#
+builder_exists() {
+    docker buildx ls --format '{{.Name}}' | grep -F -x "$1" >/dev/null
+}
+
+#
+# project_container: Print the fixture service container ID.
+#
+# Parameters: None.
+#
+# Returns: Prints the container ID or an empty line.
+#
+project_container() {
+    docker compose \
+        --project-name "${PROJECT_NAME}" \
+        --env-file "${ENV_FILE}" \
+        --file "${COMPOSE_FILE}" \
+        ps --all --quiet fixture
+}
+
+#
+# anonymous_volume: Print the fixture container's anonymous volume name.
+#
+# Parameters: $1 - Fixture container ID.
+#
+# Returns: Prints the volume mounted at /scratch.
+#
+anonymous_volume() {
+    docker container inspect \
+        --format '{{range .Mounts}}{{if eq .Destination "/scratch"}}{{.Name}}{{end}}{{end}}' \
+        "$1"
+}
+
+#
+# Create files that are isolated from both repositories and contain no secrets.
+#
+mkdir -p "${FIXTURE_DIRECTORY}" "${PROTECTED_DIRECTORY}"
+cat >"${DOCKERFILE}" <<'EOF'
+FROM busybox:1.37
+
+CMD ["sh", "-c", "sleep 600"]
+EOF
+cat >"${COMPOSE_FILE}" <<'EOF'
+services:
+  fixture:
+    build:
+      context: .
+    image: ${SERVICE_IMAGE}
+    command: ["sh", "-c", "sleep 600"]
+    volumes:
+      - fixture-data:/data
+      - /scratch
+      - ${PROTECTED_DIRECTORY}:/protected:ro
+
+volumes:
+  fixture-data:
+EOF
+cat >"${ENV_FILE}" <<EOF
+SERVICE_IMAGE=${SERVICE_IMAGE}
+PROTECTED_DIRECTORY=${PROTECTED_DIRECTORY}
+EOF
+printf '%s\n' 'protected fixture state' >"${PROTECTED_DIRECTORY}/marker.txt"
+PROTECTED_CHECKSUM=$(cksum "${PROTECTED_DIRECTORY}/marker.txt")
+ENV_CHECKSUM=$(cksum "${ENV_FILE}")
+
+trap cleanup 0 1 2 15
+
+#
+# Create unrelated resources and builders with exact disposable names.
+#
+SELECTED_BUILDER_BEFORE=$(selected_builder)
+docker pull busybox:1.37 >/dev/null
+docker image tag busybox:1.37 "${SENTINEL_IMAGE}"
+docker network create "${SENTINEL_NETWORK}" >/dev/null
+docker volume create "${SENTINEL_VOLUME}" >/dev/null
+docker container run \
+    --detach \
+    --name "${SENTINEL_CONTAINER}" \
+    --network "${SENTINEL_NETWORK}" \
+    --mount "source=${SENTINEL_VOLUME},target=/sentinel" \
+    "${SENTINEL_IMAGE}" sh -c 'sleep 600' >/dev/null
+docker buildx create \
+    --name "${BUILDER_NAME}" \
+    --driver docker-container >/dev/null
+docker buildx create \
+    --name "${SENTINEL_BUILDER_NAME}" \
+    --driver docker-container >/dev/null
+
+#
+# Ordinary down removes containers and networks but preserves both volume
+# kinds, the local image, protected files, and unrelated Docker resources.
+#
+BUILDX_BUILDER="${BUILDER_NAME}" docker compose \
+    --project-name "${PROJECT_NAME}" \
+    --env-file "${ENV_FILE}" \
+    --file "${COMPOSE_FILE}" \
+    up --detach --build
+CONTAINER_ID=$(project_container)
+[ -n "${CONTAINER_ID}" ] || fail "Compose did not create the fixture container."
+ANONYMOUS_VOLUME=$(anonymous_volume "${CONTAINER_ID}")
+[ -n "${ANONYMOUS_VOLUME}" ] || fail "Compose did not create an anonymous volume."
+
+docker compose \
+    --project-name "${PROJECT_NAME}" \
+    --env-file "${ENV_FILE}" \
+    --file "${COMPOSE_FILE}" \
+    down --timeout 5 --remove-orphans
+
+[ -z "$(project_container)" ] || fail "Ordinary down retained the fixture container."
+assert_absent "project network after down" docker network inspect "${PROJECT_NAME}_default"
+assert_present "named volume after down" docker volume inspect "${PROJECT_VOLUME}"
+assert_present "anonymous volume after down" docker volume inspect "${ANONYMOUS_VOLUME}"
+assert_present "service image after down" docker image inspect "${SERVICE_IMAGE}"
+[ "$(cksum "${PROTECTED_DIRECTORY}/marker.txt")" = "${PROTECTED_CHECKSUM}" ] \
+    || fail "Ordinary down changed protected bind-mounted state."
+
+#
+# Remove the first phase's deliberately preserved Docker artifacts so the nuke
+# phase starts as a fresh project and can prove its own complete ownership.
+#
+docker volume rm "${PROJECT_VOLUME}" "${ANONYMOUS_VOLUME}" >/dev/null
+ANONYMOUS_VOLUME=""
+docker image rm "${SERVICE_IMAGE}" >/dev/null
+
+#
+# Recreate the isolated project, then require nuke to remove its complete Docker
+# scope and named builder without disturbing any unrelated sentinel resource.
+#
+BUILDX_BUILDER="${BUILDER_NAME}" docker compose \
+    --project-name "${PROJECT_NAME}" \
+    --env-file "${ENV_FILE}" \
+    --file "${COMPOSE_FILE}" \
+    up --detach --build
+CONTAINER_ID=$(project_container)
+[ -n "${CONTAINER_ID}" ] || fail "Compose did not recreate the fixture container."
+ANONYMOUS_VOLUME=$(anonymous_volume "${CONTAINER_ID}")
+[ -n "${ANONYMOUS_VOLUME}" ] || fail "Compose did not recreate an anonymous volume."
+
+"${NUKE_HELPER}" \
+    --docker-bin docker \
+    --compose-file "${COMPOSE_FILE}" \
+    --env-file "${ENV_FILE}" \
+    --project-name "${PROJECT_NAME}" \
+    --down-timeout 5 \
+    --builder-name "${BUILDER_NAME}"
+
+[ -z "$(project_container)" ] || fail "Nuke retained the fixture container."
+assert_absent "project network after nuke" docker network inspect "${PROJECT_NAME}_default"
+assert_absent "named volume after nuke" docker volume inspect "${PROJECT_VOLUME}"
+assert_absent "anonymous volume after nuke" docker volume inspect "${ANONYMOUS_VOLUME}"
+assert_absent "service image after nuke" docker image inspect "${SERVICE_IMAGE}"
+if builder_exists "${BUILDER_NAME}"; then
+    fail "Nuke retained the configured project builder."
+fi
+
+assert_present "sentinel container" docker container inspect "${SENTINEL_CONTAINER}"
+assert_present "sentinel network" docker network inspect "${SENTINEL_NETWORK}"
+assert_present "sentinel volume" docker volume inspect "${SENTINEL_VOLUME}"
+assert_present "sentinel image" docker image inspect "${SENTINEL_IMAGE}"
+builder_exists "${SENTINEL_BUILDER_NAME}" \
+    || fail "Nuke removed the unrelated sentinel builder."
+[ "$(selected_builder)" = "${SELECTED_BUILDER_BEFORE}" ] \
+    || fail "Nuke changed the globally selected Buildx builder."
+[ "$(cksum "${PROTECTED_DIRECTORY}/marker.txt")" = "${PROTECTED_CHECKSUM}" ] \
+    || fail "Nuke changed protected bind-mounted state."
+[ "$(cksum "${ENV_FILE}")" = "${ENV_CHECKSUM}" ] \
+    || fail "Nuke changed the environment file."
+
+#
+# A second run must treat already-absent project resources as success.
+#
+"${NUKE_HELPER}" \
+    --docker-bin docker \
+    --compose-file "${COMPOSE_FILE}" \
+    --env-file "${ENV_FILE}" \
+    --project-name "${PROJECT_NAME}" \
+    --down-timeout 5 \
+    --builder-name "${BUILDER_NAME}"
+
+echo "Live Compose cleanup acceptance passed."

--- a/test/stubs/docker-nuke-stub.sh
+++ b/test/stubs/docker-nuke-stub.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# docker-nuke-stub.sh: Record Compose nuke-helper commands and return
+#                      deterministic Docker, Compose, and Buildx responses.
+#
+# Usage: NUKE_STUB_LOG=<path> test/stubs/docker-nuke-stub.sh <arguments>
+#
+
+#
+# Fail on errors and unset variables.
+#
+set -eu
+
+#
+# Require an isolated invocation log.
+#
+: "${NUKE_STUB_LOG:?NUKE_STUB_LOG is required}"
+
+#
+# Record every call without interpreting its arguments.
+#
+printf '%s\n' "$*" >>"${NUKE_STUB_LOG}"
+
+#
+# Report plugin or standalone Compose availability.
+#
+if [ "$#" -ge 1 ] && { [ "$1" = "version" ] || { [ "$1" = "compose" ] && [ "${2:-}" = "version" ]; }; }; then
+    echo "Docker Compose test stub"
+    exit 0
+fi
+
+case " $* " in
+    *" config --quiet "*)
+        if [ "${NUKE_STUB_FAIL_COMPOSE:-}" = "config" ]; then
+            exit 41
+        fi
+        exit 0
+        ;;
+    *" config --images "*)
+        printf '%s\n' \
+            'test/service:local' \
+            'test/absent:latest' \
+            'test/service:local'
+        exit 0
+        ;;
+    *" down --timeout "*)
+        if [ "${NUKE_STUB_FAIL_COMPOSE:-}" = "down" ]; then
+            exit 42
+        fi
+        exit 0
+        ;;
+    *" image ls --quiet --no-trunc "*)
+        image_reference=""
+        for argument in "$@"; do
+            image_reference=${argument}
+        done
+        case "${image_reference}" in
+            *absent*) exit 0 ;;
+            *) echo "sha256:test-image-id" ;;
+        esac
+        exit 0
+        ;;
+    *" image rm "*)
+        case " $* " in
+            *" test/shared-base:1 "*) exit 43 ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    *" buildx ls --format "*)
+        printf '%s\n' 'test-builder' 'unrelated-builder'
+        exit 0
+        ;;
+    *" buildx rm --force test-builder "*)
+        exit 0
+        ;;
+esac
+
+echo "Unexpected Docker nuke stub invocation: $*" >&2
+exit 99


### PR DESCRIPTION
## Executive summary 🌈

This PR aligns Privateerr with the shared lifecycle contract and fixes ordinary `make down` so it no longer destroys volumes.

- changes `down` to remove containers, networks, and orphans while preserving volumes and images
- removes the redundant `start` and `stop` aliases while keeping `run-privateerr` as a real project target
- replaces embedded name-based nuke logic with a documented project-scoped POSIX helper
- routes Compose and multi-platform builds through the repository-owned `privateerr-local` Buildx builder
- adds a portable Dockerfile base-image parser, deterministic stub tests, and an opt-in isolated Docker acceptance test
- uses punctuation-only test fixture names and documents every AWK function parameter, including function-local values
- suppresses the AWK extension 0.1.0 compatibility false positives while retaining POSIX AWK mode and runtime validation
- upgrades Privateerr and Buccaneerr's pinned Alpine OpenSSL libraries to 3.5.8-r0, fixing CVE-2026-14456 without suppressing the Trivy gate
- aligns common target groups, recipe order, dependency comments, option formatting, and help order with Plundarr

## Cleanup contract 🧹

| Target | Contract |
| --- | --- |
| `clean` | Removes disposable repository artifacts only; never Docker, `.env`, config, backups, or generated credentials. |
| `down` | Removes Privateerr project containers, networks, and orphans while preserving volumes and images. |
| `clean-test` | Uses volume-preserving `down`, then restores checked-in WireGuard examples. |
| `nuke` | Removes project containers, networks, volumes, service/local images, scoped builder/cache, and transient test state, then restores examples. |

## Safety boundary 🛟

`nuke` preserves `.env`, `backups/`, and the persistent bind-mounted config directory. It never runs a global prune, never uses container-name regexes, removes only the exact `privateerr-local` builder, and treats shared or in-use Dockerfile base images as best-effort cleanup.

## Validation ✅

- `make help`
- `make test-make-helpers`
- `make test-workflows`
- `make test`
- `make config ENV_FILE=example.env COMPOSE_ENV_FILE=example.env`
- `make build ENV_FILE=example.env COMPOSE_ENV_FILE=example.env`
- `make build-buccaneerr ENV_FILE=example.env COMPOSE_ENV_FILE=example.env`
- `make build-platforms` for amd64, arm64, and arm/v7
- `pre-commit run --all-files`
- fresh HIGH/CRITICAL Trivy scans: zero findings for both images with `libcrypto3` and `libssl3` at 3.5.8-r0
- POSIX AWK runtime checks and the workspace AWK language-server parser with compatibility false positives disabled
- exhaustive searches for aliases, whitespace test paths, incomplete AWK parameter comments, and Maraudarr misspellings
- isolated live Docker acceptance proving named/anonymous volume and image preservation on `down`, complete project cleanup on `nuke`, sentinel survival, exact builder removal, and unchanged protected files
- byte-for-byte `cmp` verification against the Plundarr helper, AWK parser, focused tests, and live acceptance script

No real PIA credentials, generated WireGuard state, backups, or persistent deployment config were used for destructive validation. ✨