### PR TITLE
Include Buccaneerr Dockerfile in Renovate coverage

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,20 @@
     ],
 
     //
+    // Keep the recommended dependency ignores while allowing Renovate to
+    // manage the real Buccaneerr image definition in test/Dockerfile.
+    //
+    "ignorePaths": [
+        "**/node_modules/**",
+        "**/bower_components/**",
+        "**/vendor/**",
+        "**/examples/**",
+        "**/__tests__/**",
+        "**/tests/**",
+        "**/__fixtures__/**"
+    ],
+
+    //
     // Keep dependency work predictable for a single-maintainer repository.
     //
     "timezone": "America/New_York",


### PR DESCRIPTION
## Summary
- preserve Renovate's recommended dependency exclusions
- allow the real Buccaneerr image definition under test/Dockerfile to be scanned
- raise verified extraction coverage from 48 dependencies in 11 files to 51 dependencies in 13 files

## Why
The config:recommended preset ignores test directories. That unintentionally excluded the buildable Buccaneerr Dockerfile and both of its synchronized Alpine pins from the Dependency Dashboard. Fixtures and example directories remain ignored. 🏴‍☠️🌈

## Validation
- Renovate 44.49.0 strict configuration validation
- Renovate 44.49.0 lookup-only extraction
- pre-commit run --all-files
- make test-workflows
- build-pin policy check
- Docker Compose config validation
- git diff --check