### PR TITLE
Align documentation with GitHub writing practices

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -25,7 +25,7 @@ on:
       - "Makefile"
       - "config/**"
       - "docker/**"
-      - "docs/DOCKERHUB_README.md"
+      - "docs/docker-hub-description.md"
       - "docker-compose.yml"
       - "example.env"
       - "test/**"
@@ -407,7 +407,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ github.repository_owner }}/privateerr
           short-description: "Generate PIA WireGuard config and Gluetun port forwarding metadata."
-          readme-filepath: ./docs/DOCKERHUB_README.md
+          readme-filepath: ./docs/docker-hub-description.md
 
       #
       # Report the final job state to both optional Discord destinations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Privateerr-owned code wraps the upstream scripts but should keep transparency cl
 
 ## Documentation Voice
 
-Public-facing Markdown uses the project voice: funny, pirate-themed, readable, and useful.
+Public-facing Markdown uses the project voice: funny, lightly pirate-themed, readable, and useful. Put the operational meaning first and use pirate language mainly in short introductions, transitions, and sign-offs.
 
 Use pirate humor in:
 
@@ -56,15 +56,23 @@ Use pirate humor in:
 - GitHub PR templates
 - user-facing Makefile `echo` output when appropriate
 
-Do not let jokes obscure operational meaning. Commands, paths, warnings, examples, and troubleshooting details must remain precise.
+Do not let jokes obscure operational meaning. Commands, paths, user-interface labels, warnings, security guidance, destructive actions, examples, and troubleshooting details must remain literal and precise.
 
-Use GitHub callouts where they help:
+Follow `docs/documentation-style.md` for audience, structure, sentence-case headings, filenames, links, code blocks, alerts, advanced Markdown, and rendered review. Use searchable words before decorative emoji in headings. Emoji must not carry meaning by itself.
+
+Reserve GitHub alerts for information readers must notice while scanning:
 
 - `[!NOTE]`
 - `[!TIP]`
 - `[!IMPORTANT]`
 - `[!WARNING]`
 - `[!CAUTION]`
+
+Most pages should need no more than one or two alerts. Do not wrap routine commands in alerts or place alerts back to back. Put routine copyable commands in `sh` fences without prompt characters or comments. Use `console` for terminal transcripts and `text` for non-executable output.
+
+Write each ordinary Markdown prose paragraph on one physical source line and let editors apply visual word wrapping. Preserve semantic blank lines, lists, tables, code fences, deliberate hard breaks, and other structures that require their own lines.
+
+Keep `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `SUPPORT.md` in their established form. Name ordinary documentation pages with lowercase kebab-case.
 
 ## Code Comment Style
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,57 @@
 <!-- markdownlint-disable-next-line MD033 MD041 -->
-<p align="center">
-  <em>🏴‍☠️ Generate PIA WireGuard configuration, hand it to a real VPN client, and get out of the way.</em>
-</p>
+<hr />
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/github/actions/workflow/status/scottgigawatt/privateerr/build-and-push.yml?branch=main&label=Privateerr%20build&logo=githubactions" alt="Privateerr build status" /></a>
-  <img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Release" alt="Latest Privateerr release" />
-  <a href="https://www.bestpractices.dev/projects/13442"><img src="https://www.bestpractices.dev/projects/13442/badge" alt="OpenSSF Best Practices" /></a>
-  <img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=License" alt="Apache 2.0 license" />
-  <img src="https://img.shields.io/badge/Platforms-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=docker" alt="Published for amd64, arm64, and arm/v7" />
-  <img src="https://img.shields.io/badge/Scanned-Trivy-teal?logo=aqua" alt="Container image scanned with Trivy" />
+  <em>🦜 Parrot says: Found this useful? Drop a ⭐ an' help another crew find the map.</em>
+</p>
+
+<p align="center">
+  <a href="https://github.com/scottgigawatt/privateerr/stargazers"><img src="https://img.shields.io/github/stars/scottgigawatt/privateerr?style=social&amp;label=Treasure%20Hunters" alt="GitHub stars: Treasure Hunters" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/forks"><img src="https://img.shields.io/github/forks/scottgigawatt/privateerr?style=social&amp;label=Mutinous%20Forks" alt="GitHub forks: Mutinous Forks" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/watchers"><img src="https://img.shields.io/github/watchers/scottgigawatt/privateerr?style=social&amp;label=Crow%27s%20Nest%20Lookouts" alt="GitHub watchers: Crow's Nest Lookouts" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/scottgigawatt/privateerr/releases/latest"><img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Latest%20Treasure%20Map&amp;logo=github&amp;color=1677B8" alt="Latest Privateerr release" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/github/actions/workflow/status/scottgigawatt/privateerr/build-and-push.yml?branch=main&amp;label=Privateerr%20build&amp;logo=githubactions&amp;logoColor=white" alt="Privateerr build status on main" /></a>
+  <a href="https://www.bestpractices.dev/projects/13442"><img src="https://www.bestpractices.dev/projects/13442/badge" alt="OpenSSF Best Practices badge" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/badge/Scanned-Trivy%20Bilge%20Check-008B8B?logo=aqua&amp;logoColor=white" alt="Container images scanned with Trivy" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=Legal%20Scroll&amp;color=1677B8" alt="Legal Scroll: Apache 2.0 license" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/GHCR-Privateerr%20Captain-1677B8?logo=github&amp;logoColor=white" alt="Privateerr image on GitHub Container Registry" /></a>
+  <a href="https://hub.docker.com/r/scottgigawatt/privateerr"><img src="https://img.shields.io/docker/pulls/scottgigawatt/privateerr?label=Docker%20Hub%20Privateerr&amp;logo=docker&amp;color=1677B8" alt="Privateerr pulls from Docker Hub" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Dockerized-Brig-2496ED?logo=docker&amp;logoColor=white" alt="Dockerized brig" />
+  <img src="https://img.shields.io/badge/Cloaked-by%20PIA%20%26%20WireGuard-2EA44F?logo=wireguard&amp;logoColor=white" alt="Cloaked by PIA and WireGuard" />
+  <a href="./docker/Dockerfile"><img src="https://img.shields.io/badge/Base-Alpine%20Pinned-0D597F?logo=alpinelinux&amp;logoColor=white" alt="Pinned Alpine base image" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/Multi--Arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-1677B8?logo=docker&amp;logoColor=white" alt="Privateerr images for amd64, arm64, and arm/v7" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Battle--Tested-Synology%20%7C%20macOS-1677B8" alt="Battle-tested on Synology and macOS" />
+  <a href="https://github.com/scottgigawatt/privateerr/commits/main"><img src="https://img.shields.io/github/last-commit/scottgigawatt/privateerr?label=Last%20Raid&amp;logo=git&amp;color=2EA44F" alt="Date of the last commit to main" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr"><img src="https://img.shields.io/github/repo-size/scottgigawatt/privateerr?label=Hold%20Capacity&amp;color=1677B8" alt="Privateerr repository size" /></a>
+  <img src="https://img.shields.io/badge/Rum%20Rations-Plentiful-E66A24" alt="Rum rations: Plentiful" />
+</p>
+
+<p align="center">─── ⛧ ───</p>
+
+<p align="center">
+  <em>💀 Questions or cursed code? Step forward… <strong>enter 🔥HADES🔥</strong>.</em>
 </p>
 
 <p align="center">
   <a href="https://discord.gg/BpEGzWwGYf"><img src="https://img.shields.io/discord/1403601106315116626?label=%F0%9F%94%A5HADES%F0%9F%94%A5&logo=discord&logoColor=white&color=5865F2" alt="HADES Discord community" /></a>
 </p>
 <!-- markdownlint-enable MD033 -->
+
+<!-- markdownlint-disable-next-line MD033 -->
+<hr />
 
 # Privateerr 🏴‍☠️
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml/badge.svg" alt="Privateerr build status" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/github/actions/workflow/status/scottgigawatt/privateerr/build-and-push.yml?branch=main&label=Privateerr%20build&logo=githubactions" alt="Privateerr build status" /></a>
   <img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Release" alt="Latest Privateerr release" />
   <a href="https://www.bestpractices.dev/projects/13442"><img src="https://www.bestpractices.dev/projects/13442/badge" alt="OpenSSF Best Practices" /></a>
   <img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=License" alt="Apache 2.0 license" />

--- a/README.md
+++ b/README.md
@@ -55,36 +55,36 @@
 
 # Privateerr 🏴‍☠️
 
-Privateerr packages the official, unmodified [Private Internet Access manual-connection scripts](https://github.com/pia-foss/manual-connections) in a small Alpine container. It runs those scripts to generate a PIA WireGuard configuration and writes a companion metadata file for Gluetun automation.
+Privateerr is a containerized configuration tool for [Private Internet Access (PIA)](https://www.privateinternetaccess.com/). It packages PIA's official, unmodified [manual-connection scripts](https://github.com/pia-foss/manual-connections) in a small Alpine container and uses them to generate a WireGuard configuration file plus PIA server metadata for automation.
+
+Use Privateerr when you want `wg0.conf` for Gluetun, WireGuard, or another compatible VPN client—especially when a Docker Compose deployment needs to generate that configuration repeatably.
 
 > [!IMPORTANT]
 > Privateerr is not a virtual private network (VPN) client. It does not create or maintain a tunnel. It generates `wg0.conf` for a VPN client such as Gluetun or WireGuard.
 
-The upstream PIA scripts remain visible as the `docker/pia-manual-connections` submodule. Privateerr adds repeatable container execution, safe defaults, health reporting, and a small metadata handoff without modifying the upstream scripts.
+The upstream PIA scripts remain visible as the `docker/pia-manual-connections` submodule. Privateerr adds repeatable container execution, safe defaults, health reporting, and a small metadata handoff without modifying those scripts.
 
 ## Understand the data flow 🧭
 
-Privateerr runs first and writes two files. Gluetun then uses `wg0.conf` to establish the VPN tunnel and reads `PIA_WG_SERVER_NAME` from `privateerr.env` when PIA port forwarding is enabled. The test-only Buccaneerr image can validate the completed path from inside Gluetun's network namespace.
+Privateerr runs before the VPN client and writes two files. Gluetun—a separate VPN client container—uses `wg0.conf` to establish the tunnel and reads `PIA_WG_SERVER_NAME` from `privateerr.env` when PIA port forwarding is enabled. Other Compose services can then share Gluetun's protected network connection.
 
 ```mermaid
 flowchart TB
     PIA["PIA manual-connection scripts"]
-    Privateerr["Privateerr generates configuration"]
+    Privateerr["Privateerr generates PIA WireGuard configuration"]
     Files["wg0.conf + privateerr.env"]
     Gluetun["Gluetun starts the VPN tunnel"]
     Services["Compose services use Gluetun networking"]
-    Buccaneerr["Buccaneerr validates the test voyage"]
 
     PIA -->|unmodified scripts| Privateerr
     Privateerr -->|writes| Files
     Files -->|WireGuard config and server metadata| Gluetun
     Gluetun -->|protected network namespace| Services
-    Gluetun -.->|test-only validation| Buccaneerr
 ```
 
 ## Generate a WireGuard configuration ⚡
 
-Clone the repository with its PIA submodule, create the private environment file, and edit the PIA values before running Privateerr:
+Before you begin, you need an active PIA subscription plus Git, Docker with Docker Compose, and Make. Clone the repository with its PIA submodule, create the private environment file, and edit the PIA values before running Privateerr:
 
 ```sh
 git clone --recurse-submodules https://github.com/scottgigawatt/privateerr.git
@@ -92,7 +92,7 @@ cd privateerr
 cp example.env .env
 ```
 
-Set `PIA_USER`, `PIA_PASS`, and the desired `PIA_PF` value in `.env`. Keep that file private. Generate fresh configuration:
+Set `PIA_USER` and `PIA_PASS` in `.env`. Set `PIA_PF=true` if you need a PIA endpoint that supports port forwarding; otherwise leave it `false`. Keep the file private, then generate fresh configuration:
 
 ```sh
 make run-privateerr
@@ -100,10 +100,10 @@ make run-privateerr
 
 Privateerr writes:
 
-| File | Purpose |
-| --- | --- |
-| `config/gluetun/wireguard/wg0.conf` | PIA WireGuard configuration for Gluetun, WireGuard, or another compatible client |
-| `config/gluetun/wireguard/privateerr.env` | Selected PIA endpoint, region, and port-forwarding metadata for automation |
+| 📦 Output | 📍 Path | 🎯 Used by |
+| --- | --- | --- |
+| 🛡️ WireGuard configuration | `config/gluetun/wireguard/wg0.conf` | Gluetun, WireGuard, or another compatible VPN client |
+| 🧭 PIA server metadata | `config/gluetun/wireguard/privateerr.env` | Compose automation that needs the selected endpoint, region, or port-forwarding details |
 
 > [!WARNING]
 > Keep live `wg0.conf` and `privateerr.env` files private. They can contain VPN connection material and deployment-specific metadata. Run `make restore-test-config` before committing after a live voyage.
@@ -191,19 +191,19 @@ The `PIA_*` variables map Privateerr defaults to values understood by the upstre
 
 ## Use common maintenance commands ⚙️
 
-| Command | Use it when |
+| ⚙️ Command | 🧭 Use it when |
 | --- | --- |
-| `make run-privateerr` | You need fresh `wg0.conf` and `privateerr.env` only |
-| `make up` | You want the Privateerr and Gluetun Compose stack |
-| `make down` | You want to stop the stack while preserving volumes and images |
-| `make ps` | You need compact service status |
-| `make logs` | You need container output |
-| `make backup` | You want a recoverable archive of `config/` |
-| `make test` | You want the offline policy and helper suite |
-| `make clean-test` | You want to stop tests and restore checked-in examples |
-| `make restore-test-config` | You want to restore only checked-in examples |
-| `make clean` | You want to remove disposable repository artifacts only |
-| `make nuke` | You intend to remove project Docker resources and transient state |
+| ⚡ `make run-privateerr` | You need fresh `wg0.conf` and `privateerr.env` only |
+| 🚢 `make up` | You want the Privateerr and Gluetun Compose stack |
+| ⚓ `make down` | You want to stop the stack while preserving volumes and images |
+| 🔎 `make ps` | You need compact service status |
+| 📜 `make logs` | You need container output |
+| 💾 `make backup` | You want a recoverable archive of `config/` |
+| 🧪 `make test` | You want the offline policy and helper suite |
+| 🧹 `make clean-test` | You want to stop tests and restore checked-in examples |
+| ♻️ `make restore-test-config` | You want to restore only checked-in examples |
+| 🧽 `make clean` | You want to remove disposable repository artifacts only |
+| 💣 `make nuke` | You intend to remove project Docker resources and transient state |
 
 `make nuke` removes this project's containers, networks, volumes, service and local images, and repository-owned Buildx cache. It preserves `.env`, `backups/`, and persistent `config/`, then restores the checked-in WireGuard examples. Shared or in-use base images remain.
 
@@ -211,12 +211,12 @@ The `PIA_*` variables map Privateerr defaults to values understood by the upstre
 
 Images are published to [GitHub Container Registry](https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr) and [Docker Hub](https://hub.docker.com/r/scottgigawatt/privateerr) for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
 
-| Channel | Meaning |
+| 📦 Channel | 🧭 Choose it when |
 | --- | --- |
-| `latest` | Newest stable release; recommended for most users |
-| `edge` | Newest successful `main` build; may change before release |
-| Exact version | One immutable semantic-version release, such as `1.2.3` |
-| `sha-...` | Image built from one source revision |
+| ✅ `latest` | You want the newest stable release; recommended for most users |
+| 🧪 `edge` | You want the newest successful `main` build and accept changes before release |
+| ⚓ Exact version | You want one immutable semantic-version release, such as `1.2.3` |
+| 🔬 `sha-...` | You need the image built from one exact source revision |
 
 Stable releases also publish minor and stable-major aliases. Major version zero omits the broad `0` alias, and prereleases never replace movable stable aliases.
 

--- a/README.md
+++ b/README.md
@@ -1,96 +1,98 @@
-<!-- markdownlint-disable MD033 MD041 -->
-
-<hr />
-
+<!-- markdownlint-disable-next-line MD033 MD041 -->
 <p align="center">
-  <em>🦜 Parrot says: Smash that ⭐️ or walk the plank, ye landlubber!</em>
+  <em>🏴‍☠️ Generate PIA WireGuard configuration, hand it to a real VPN client, and get out of the way.</em>
 </p>
 
+<!-- markdownlint-disable MD033 -->
 <p align="center">
-  <img src="https://img.shields.io/github/stars/scottgigawatt/privateerr?label=Treasure%20Hunters&logo=github" alt="Treasure Hunters" />
-  <img src="https://img.shields.io/github/forks/scottgigawatt/privateerr?label=Mutinous%20Forks&logo=github" alt="Mutinous Forks" />
-  <img src="https://img.shields.io/github/watchers/scottgigawatt/privateerr?label=Crow's%20Nest%20Lookouts&logo=github" alt="Crow's Nest Lookouts" />
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Latest%20Treasure%20Map&logo=github" alt="Latest Treasure Map" />
-  <img src="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml/badge.svg" alt="🏴‍☠️ Build: Shipshape" />
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml/badge.svg" alt="Privateerr build status" /></a>
+  <img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Release" alt="Latest Privateerr release" />
   <a href="https://www.bestpractices.dev/projects/13442"><img src="https://www.bestpractices.dev/projects/13442/badge" alt="OpenSSF Best Practices" /></a>
-  <img src="https://img.shields.io/badge/Scanned-Trivy%20Bilge%20Check-teal?logo=aqua" alt="Trivy Bilge Check" />
-  <img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=Legal%20Scroll&color=blue" alt="Legal Scroll" />
-  <img src="https://img.shields.io/badge/GHCR-Privateerr%20Captain-blue?logo=github" alt="GHCR Privateerr Captain" />
-  <img src="https://img.shields.io/docker/pulls/scottgigawatt/privateerr?label=Docker%20Hub%20Privateerr&logo=docker" alt="Docker Hub Privateerr Pulls" />
-  <img src="https://img.shields.io/badge/Dockerized-Brig-blue?logo=docker" alt="Dockerized Brig" />
-  <img src="https://img.shields.io/badge/Cloaked-by%20PIA%20%26%20WireGuard-green?logo=protonvpn" alt="Cloaked" />
-  <img src="https://img.shields.io/badge/Base-Alpine%20Pinned-0D597F?logo=alpinelinux" alt="Alpine Pinned" />
-  <img src="https://img.shields.io/badge/Multi--Arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=docker" alt="Multi-Arch amd64, arm64, and arm/v7" />
-  <img src="https://img.shields.io/badge/Battle--Tested-Synology%20%7C%20macOS-blue" alt="Battle-Tested" />
-  <img src="https://img.shields.io/github/last-commit/scottgigawatt/privateerr?label=Last%20Raid&logo=git" alt="Last Raid" />
-  <img src="https://img.shields.io/github/repo-size/scottgigawatt/privateerr?label=Hold%20Capacity" alt="Hold Capacity" />
-  <img src="https://img.shields.io/badge/Rum%20Rations-Plentiful-orange" alt="Rum Rations" />
-</p>
-
-<p align="center">─── ⛧ ───</p>
-
-<p align="center">
-    <em>💀 Need help or wanna trade cursed tech tips over lava? Step forward… <strong>Enter 🔥HADES🔥</strong>.</em>
+  <img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=License" alt="Apache 2.0 license" />
+  <img src="https://img.shields.io/badge/Platforms-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=docker" alt="Published for amd64, arm64, and arm/v7" />
+  <img src="https://img.shields.io/badge/Scanned-Trivy-teal?logo=aqua" alt="Container image scanned with Trivy" />
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/BpEGzWwGYf">
-    <img src="https://img.shields.io/discord/1403601106315116626?label=%F0%9F%94%A5HADES%F0%9F%94%A5&logo=discord&logoColor=white&color=5865F2" alt="🔥HADES🔥 Discord" />
-  </a>
+  <a href="https://discord.gg/BpEGzWwGYf"><img src="https://img.shields.io/discord/1403601106315116626?label=%F0%9F%94%A5HADES%F0%9F%94%A5&logo=discord&logoColor=white&color=5865F2" alt="HADES Discord community" /></a>
 </p>
+<!-- markdownlint-enable MD033 -->
 
-<hr />
+# Privateerr 🏴‍☠️
 
-# ⚓️ Privateerr ☠️🏴‍☠️
-
-Ahoy! Privateerr is a lightweight Docker image that packages the official, unmodified,   Private Internet Access (PIA) ✨ [pia-foss/manual-connections](https://github.com/pia-foss/manual-connections) ✨ scripts.
-
-Those PIA scripts live in this repo as a submodule at `docker/pia-manual-connections`; Privateerr packages them into a small Alpine image, runs them, and makes the output easy to use and consume with automation.
-
-And that's it! That's the whole trick: PIA's original scripts do the WireGuard work. Privateerr just gives them a clean container, friendly defaults, repeatable commands, and a small metadata file for Docker Compose setups.
+Privateerr packages the official, unmodified [Private Internet Access manual-connection scripts](https://github.com/pia-foss/manual-connections) in a small Alpine container. It runs those scripts to generate a PIA WireGuard configuration and writes a companion metadata file for Gluetun automation.
 
 > [!IMPORTANT]
->
-> **Privateerr is NOT a VPN client.** It does not create or run a VPN tunnel. It generates a PIA WireGuard configuration file (`wg0.conf`) that you can hand to an actual VPN client.
+> Privateerr is not a virtual private network (VPN) client. It does not create or maintain a tunnel. It generates `wg0.conf` for a VPN client such as Gluetun or WireGuard.
 
-There are already excellent VPN clients. One of the best container-friendly options is [Gluetun](https://github.com/qdm12/gluetun). If what you really want is "get Gluetun working with PIA WireGuard," Privateerr may have you covered: generate the files, point Gluetun at them, and move on.
+The upstream PIA scripts remain visible as the `docker/pia-manual-connections` submodule. Privateerr adds repeatable container execution, safe defaults, health reporting, and a small metadata handoff without modifying the upstream scripts.
 
-## ⚡ Fastest Path
+## Understand the data flow 🧭
 
-Clone the repo with submodules, copy the example environment file, then pass your PIA credentials inline:
+Privateerr runs first and writes two files. Gluetun then uses `wg0.conf` to establish the VPN tunnel and reads `PIA_WG_SERVER_NAME` from `privateerr.env` when PIA port forwarding is enabled. The test-only Buccaneerr image can validate the completed path from inside Gluetun's network namespace.
 
-```sh
-git clone --recurse-submodules git@github.com:scottgigawatt/privateerr.git
-cd privateerr
-cp example.env .env
-PIA_USER="p1234567" PIA_PASS="p0rtRoya1" PIA_PF="false" make run-privateerr
+```mermaid
+flowchart TB
+    PIA["PIA manual-connection scripts"]
+    Privateerr["Privateerr generates configuration"]
+    Files["wg0.conf + privateerr.env"]
+    Gluetun["Gluetun starts the VPN tunnel"]
+    Services["Compose services use Gluetun networking"]
+    Buccaneerr["Buccaneerr validates the test voyage"]
+
+    PIA -->|unmodified scripts| Privateerr
+    Privateerr -->|writes| Files
+    Files -->|WireGuard config and server metadata| Gluetun
+    Gluetun -->|protected network namespace| Services
+    Gluetun -.->|test-only validation| Buccaneerr
 ```
 
-You don't even need to look at or update the `.env` file to get a fully functioning WireGuard configuration file _in seconds!_ Now, the `.env` file is intentionally roomy, but the defaults are ready to go; just use inline variables to override anything in the `.env` file for that run.
+## Generate a WireGuard configuration ⚡
 
-When the command finishes, the main file you came for is here:
+Clone the repository with its PIA submodule, create the private environment file, and edit the PIA values before running Privateerr:
 
 ```sh
-cat config/gluetun/wireguard/wg0.conf
+git clone --recurse-submodules https://github.com/scottgigawatt/privateerr.git
+cd privateerr
+cp example.env .env
+```
+
+Set `PIA_USER`, `PIA_PASS`, and the desired `PIA_PF` value in `.env`. Keep that file private. Generate fresh configuration:
+
+```sh
+make run-privateerr
+```
+
+Privateerr writes:
+
+| File | Purpose |
+| --- | --- |
+| `config/gluetun/wireguard/wg0.conf` | PIA WireGuard configuration for Gluetun, WireGuard, or another compatible client |
+| `config/gluetun/wireguard/privateerr.env` | Selected PIA endpoint, region, and port-forwarding metadata for automation |
+
+> [!WARNING]
+> Keep live `wg0.conf` and `privateerr.env` files private. They can contain VPN connection material and deployment-specific metadata. Run `make restore-test-config` before committing after a live voyage.
+
+<!-- markdownlint-disable MD033 -->
+<details>
+<summary>View abbreviated example output</summary>
+
+The checked-in examples use fake pirate-flavored data. A real run overwrites them.
+
+```text
 [Interface]
 Address = 10.10.10.10
-PrivateKey = shiverMeTimbers123
+PrivateKey = EXAMPLE-PRIVATE-KEY
 DNS = 10.10.10.10
 
 [Peer]
 PersistentKeepalive = 25
-PublicKey = yoHoHoPublicKey123
+PublicKey = EXAMPLE-PUBLIC-KEY
 AllowedIPs = 0.0.0.0/0
 Endpoint = 10.10.10.10:1234
 ```
 
-Privateerr also writes a tiny metadata file beside the WireGuard config:
-
-```sh
-cat config/gluetun/wireguard/privateerr.env
+```text
 PIA_WG_SERVER_NAME=jolly-roger-401
 PIA_WG_ENDPOINT_IP=10.10.10.10
 PIA_WG_ENDPOINT_PORT=1234
@@ -100,194 +102,108 @@ PIA_PORT_FORWARDING_SUPPORTED=true
 PIA_GEOLOCATED_REGION=false
 ```
 
-| 📄 File                                   | 🎯 What it is for                                                                                                                        |
-| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `config/gluetun/wireguard/wg0.conf`       | The WireGuard config generated by PIA's scripts. Use this with Gluetun, WireGuard, or another VPN client that accepts WireGuard configs. |
-| `config/gluetun/wireguard/privateerr.env` | A small helper file with the selected PIA server name, endpoint, region, and port-forwarding support metadata.                           |
+</details>
+<!-- markdownlint-enable MD033 -->
 
-> [!WARNING]
->
-> Keep `wg0.conf` private. It contains VPN connection material.
+## Enable PIA port forwarding 🚪
 
-## 🚪 Port Forwarding
-
-Want a port-forwarding-capable PIA server? Change one variable:
+Set `PIA_PF=true` in `.env`, then regenerate the files:
 
 ```sh
-PIA_USER="p1234567" PIA_PASS="p0rtRoya1" PIA_PF="true" make run-privateerr
+make run-privateerr
 ```
 
-PIA port forwarding is usually awkward because the server choice matters after WireGuard is involved. Privateerr makes the handoff simple: with `PIA_PF=true`, it asks PIA for a port-forwarding-capable WireGuard endpoint, generates `wg0.conf`, figures out the matching PIA WireGuard server name, and writes that name into `privateerr.env`.
+Privateerr asks PIA for a port-forwarding-capable WireGuard endpoint and writes the matching server name to `privateerr.env`. The included Gluetun wrapper exports that value as `SERVER_NAMES` before starting Gluetun, allowing Gluetun to request the forwarded port from the correct PIA server.
 
-The metadata in `privateerr.env` is what lets a Docker Compose stack establish a fully functioning port forwarded VPN connection in _one single step_, in _less than 1 minute_. Privateerr writes the map, reads `PIA_WG_SERVER_NAME`, exports it as `SERVER_NAMES`, then Gluetun can start immediately with the right server information instead of making you run a second manual step _after_ the VPN connection is established.
+If you only need a WireGuard file, take `wg0.conf` and use it with the compatible client of your choice. If you want the complete automated handoff, use the included Compose stack or the larger [Plundarr project](https://github.com/scottgigawatt/plundarr#readme).
 
-> [!TIP]
->
-> For the simplest use case, take `wg0.conf` and leave. For the powerful use case, pair Privateerr with Gluetun in Compose so config generation, server-name handoff, and VPN startup happen together.
+## Start Privateerr with Gluetun 🐳
 
-For the wired-together version, see the included [Compose file](./docker-compose.yml). For a larger real-world stack, see [Plundarr](https://github.com/scottgigawatt/plundarr#readme).
+The repository includes one Synology-friendly `docker-compose.yml` that runs Privateerr before Gluetun:
 
-## 🔎 Inspect The Knobs
+```sh
+make up
+```
 
-Curious about every variable available in this project? Run:
+Inspect what Compose will run:
+
+```sh
+make print-config
+make config
+make ps
+```
+
+- `make print-config` prints the project Compose file without comments while leaving variables visible.
+- `make config` prints the fully resolved Compose model using `.env`.
+- `make ps` prints a compact status table for this Compose project.
+
+## Inspect environment values 🔎
+
+Print every resolved environment value:
 
 ```sh
 make env
 ```
 
-If you only care about the PIA settings, anchor the grep at the start of the line:
+Filter the output when investigating one integration:
 
 ```sh
-make env | grep ^PIA
-PIA_BIN_HOME=/pia
-PIA_VPN_PROTOCOL=wireguard
-PIA_DISABLE_IPV6=yes
-...
+make env | grep '^PIA'
+make env | grep '^GLUETUN'
 ```
 
-If you want to see the Gluetun side:
+The `PIA_*` variables map Privateerr defaults to values understood by the upstream scripts. Other variables configure images, mounts, healthchecks, Gluetun handoff, logs, and testing. See `example.env` for the complete documented set.
 
-```sh
-make env | grep ^GLUETUN
-GLUETUN_TAG=latest
-GLUETUN_CONFIG_PATH=./config/gluetun
-GLUETUN_WRAPPER_SCRIPT_PATH=./config/gluetun/scripts/gluetun-entrypoint-wrapper.sh
-...
-```
+## Use common maintenance commands ⚙️
 
-## 🧩 PIA Script Variables
+| Command | Use it when |
+| --- | --- |
+| `make run-privateerr` | You need fresh `wg0.conf` and `privateerr.env` only |
+| `make up` | You want the Privateerr and Gluetun Compose stack |
+| `make down` | You want to stop the stack while preserving volumes and images |
+| `make ps` | You need compact service status |
+| `make logs` | You need container output |
+| `make backup` | You want a recoverable archive of `config/` |
+| `make test` | You want the offline policy and helper suite |
+| `make clean-test` | You want to stop tests and restore checked-in examples |
+| `make restore-test-config` | You want to restore only checked-in examples |
+| `make clean` | You want to remove disposable repository artifacts only |
+| `make nuke` | You intend to remove project Docker resources and transient state |
 
-These are the environment variables understood by PIA's own manual connection scripts. Privateerr did not invent them; it passes these values through to the scripts from [pia-foss/manual-connections](https://github.com/pia-foss/manual-connections). Everything else in `.env` is scaffolding around that core: Docker image paths, Compose mounts, healthchecks, Gluetun handoff, logs, and test automation.
+`make nuke` removes this project's containers, networks, volumes, service and local images, and repository-owned Buildx cache. It preserves `.env`, `backups/`, and persistent `config/`, then restores the checked-in WireGuard examples. Shared or in-use base images remain.
 
-| 🧩 PIA script variable | 🛠️ Privateerr `.env` variable  | What it configures                                                                                                      |
-| ---------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `PIA_USER`             | `PIA_USER`                     | Your PIA username.                                                                                                      |
-| `PIA_PASS`             | `PIA_PASS`                     | Your PIA password.                                                                                                      |
-| `DIP_TOKEN`            | `PIA_DIP_TOKEN`                | Optional PIA dedicated IP token.                                                                                        |
-| `PIA_DNS`              | `PIA_DNS`                      | Whether PIA should write DNS settings into the generated config.                                                        |
-| `PIA_PF`               | `PIA_PF`                       | Whether to request a port-forwarding-capable PIA region.                                                                |
-| `PIA_CONNECT`          | `PIA_CONNECT`                  | Whether the PIA script should connect after generating config. Privateerr sets this to `false` so it only writes files. |
-| `PIA_CONF_PATH`        | `PIA_CONF_PATH`                | Where the WireGuard config file is written inside the container.                                                        |
-| `MAX_LATENCY`          | Not set by default             | Optional latency threshold used by PIA's region selection.                                                              |
-| `AUTOCONNECT`          | `PIA_AUTOCONNECT`              | Whether PIA should pick the lowest-latency region automatically.                                                        |
-| `PREFERRED_REGION`     | Not set by default             | Optional PIA region ID when you want to choose a specific region.                                                       |
-| `VPN_PROTOCOL`         | `PIA_VPN_PROTOCOL`             | Which PIA protocol to use. Privateerr uses `wireguard`.                                                                 |
-| `DISABLE_IPV6`         | `PIA_DISABLE_IPV6`             | Whether PIA's scripts should disable IPv6 behavior.                                                                     |
+## Choose an image channel 📦
 
-## 🧭 Compose Automation
+Images are published to [GitHub Container Registry](https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr) and [Docker Hub](https://hub.docker.com/r/scottgigawatt/privateerr) for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
 
-The included [docker-compose.yml](./docker-compose.yml) is intentionally variable-heavy. That keeps the file reusable, but it can make it hard to read raw.
+| Channel | Meaning |
+| --- | --- |
+| `latest` | Newest stable release; recommended for most users |
+| `edge` | Newest successful `main` build; may change before release |
+| Exact version | One immutable semantic-version release, such as `1.2.3` |
+| `sha-...` | Image built from one source revision |
 
-Use these commands when you want Docker Compose to show you what it sees:
+Stable releases also publish minor and stable-major aliases. Major version zero omits the broad `0` alias, and prereleases never replace movable stable aliases.
 
-| 🧭 Command          | 📄 What it prints                                                            |
-| ------------------- | ---------------------------------------------------------------------------- |
-| `make print-config` | The project Compose file with comments removed, but variables still visible. |
-| `make config`       | The fully rendered Docker Compose model with variables resolved from `.env`. |
+Read [advanced usage](docs/advanced-usage.md) for multi-architecture builds, end-to-end validation, release channels, registry mirroring, pinned inputs, and generated-file maintenance.
 
-So if you want to inspect the template, run:
+## Understand supply-chain controls 🛡️
 
-```sh
-make print-config
-```
+Privateerr pins GitHub Actions to full commit hashes and Alpine build bases to image digests. Renovate proposes reviewed updates for actions, Docker images, and the upstream submodule. Pull request validation, CodeQL, OpenSSF Scorecard, Trivy, software bills of materials, and provenance attestations protect the build and publication path.
 
-If you want to see the actual Compose configuration Docker will run:
+Successful `main` builds publish `edge`; only a reviewed stable version advances `latest`. Rebuilding the same source commit does not silently select a newer Alpine base.
 
-```sh
-make config
-```
+## Read more and get help 📚
 
-## ⚙️ Useful Commands
+- [Advanced usage](docs/advanced-usage.md): Testing, builds, publishing, maintenance, and generated files.
+- [Configuration directories](config/README.md): Runtime state and Gluetun handoff paths.
+- [Host scripts](scripts/README.md): Backup, credential preflight, cleanup, and status helpers.
+- [Buccaneerr testing](test/README.md): Offline checks and live end-to-end validation.
+- [Support](docs/SUPPORT.md): Usage questions, bugs, documentation requests, and safe reporting routes.
+- [Contributing](docs/CONTRIBUTING.md): Development setup and pull request expectations.
+- [Security policy](docs/SECURITY.md): Supported versions and private vulnerability reporting.
+- [Code of Conduct](docs/CODE_OF_CONDUCT.md): Community expectations and enforcement.
 
-| ⚙️ Command                 | ✅ Use it when                                          |
-| -------------------------- | ------------------------------------------------------- |
-| `make run-privateerr`      | You only want fresh `wg0.conf` and `privateerr.env`.    |
-| `make up`                  | You want the full Privateerr + Gluetun Compose stack.   |
-| `make down`                | You want to stop the stack but preserve volumes/images. |
-| `make ps`                  | You want a compact container status table.              |
-| `make logs`                | You want to inspect container output.                   |
-| `make backup`              | You want a recoverable archive of the config directory. |
-| `make test`                | You want the local policy and automation-helper suite.  |
-| `make print-config`        | You want the Compose template without comments.         |
-| `make config`              | You want the fully rendered Compose model.              |
-| `make clean`               | You want to remove only disposable developer artifacts. |
-| `make clean-test`          | You want to stop tests and restore example config.      |
-| `make restore-test-config` | You want to restore only the checked-in examples.       |
-| `make nuke`                | You want to remove project Docker resources and transient state. |
+Privateerr is licensed under the [Apache License 2.0](LICENSE). The bundled PIA manual-connection scripts remain under PIA's [MIT license](https://github.com/pia-foss/manual-connections/blob/master/LICENSE).
 
-> [!CAUTION]
-> `make nuke` removes Privateerr's containers, networks, volumes, service and
-> local images, and repository-owned Buildx cache. It restores the checked-in
-> WireGuard examples but preserves `.env`, `backups/`, and the persistent
-> `config/` directory. Declared Dockerfile base images are removed only when
-> Docker reports that they are not shared or in use.
-
-> [!TIP]
->
-> More build, test, and release details live in [Advanced Usage](./docs/ADVANCED_USAGE.md).
-
-## 📦 Platform Notes
-
-The image builds from Alpine for a small footprint. Alpine is not a distro PIA lists as officially confirmed for the manual scripts, so this project validates the container path separately before publishing images.
-
-Published Privateerr images support `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
-
-Images are published to both [GHCR](https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr) and [Docker Hub](https://hub.docker.com/repository/docker/scottgigawatt/privateerr/general). Most users should stay on `latest`; use `edge` only when ye intentionally want the newest successful `main` build before it becomes a stable release.
-
-| 📦 Registry | ✅ Stable                                 | 🧪 Edge                                 |
-| ----------- | ----------------------------------------- | --------------------------------------- |
-| GHCR        | `ghcr.io/scottgigawatt/privateerr:latest` | `ghcr.io/scottgigawatt/privateerr:edge` |
-| Docker Hub  | `scottgigawatt/privateerr:latest`         | `scottgigawatt/privateerr:edge`         |
-
-Stable releases also publish minor and major aliases: `1.2.3` moves `1.2` and `1` alongside `latest`. Major version zero keeps the safer exact and minor aliases without publishing a broad `0` tag. Commit tags such as `sha-cfa2fb5` identify a particular source revision. Prerelease tags keep only their exact version and commit tag, never replacing movable stable aliases.
-
-The Docker Hub overview is generated from [docs/DOCKERHUB_README.md](./docs/DOCKERHUB_README.md), which keeps Docker Hub focused on pulling the image and understanding the basic use case. The full project docs stay here in the GitHub README.
-
-## 🛡️ Supply Chain Notes
-
-Privateerr keeps the build deck intentionally locked down:
-
-- GitHub Actions are pinned to full commit SHAs.
-- Alpine build bases are pinned to versioned image digests.
-- Renovate opens update PRs for pinned actions, Docker digests, Compose images, and submodules.
-- Pre-commit, CodeQL, OpenSSF Scorecard, and Trivy guard the repo and image workflow.
-- Successful `main` builds publish `edge`; stable semantic-version tags publish exact, minor, major, and `latest` aliases.
-- Published images are scanned with Trivy, attested, and mirrored from GHCR to Docker Hub with digest preservation.
-
-This means a new `main` build does **not** replace the stable `latest` image or silently float to a newer Alpine base just because Alpine published one. Renovate has to raise the flag, CI has to pass, and the update has to merge before `edge` uses that new base. A reviewed version tag is still required to move `latest`.
-
-## ⚖️ License And Community
-
-Privateerr is licensed under Apache 2.0; see [LICENSE](LICENSE). The bundled PIA manual connection scripts are licensed under MIT by PIA; see their [license](https://github.com/pia-foss/manual-connections/blob/master/LICENSE).
-
-### 📖 Community Guides
-
-| 📚 Guide                                      | 🧭 Purpose                                                            |
-| --------------------------------------------- | --------------------------------------------------------------------- |
-| 🤝 [Contributing](docs/CONTRIBUTING.md)       | How to offer changes without sinking the dinghy.                      |
-| ⚖️ [Code of Conduct](docs/CODE_OF_CONDUCT.md) | Pirate manners, but useful.                                           |
-| 🔐 [Security Policy](docs/SECURITY.md)        | How to report leaky hulls without shouting secrets across the harbor. |
-
----
-
-```text
-               ______
-            .-'      `-.
-           /            \
-          |              |
-          |,  .-.  .-.  ,|
-          | )(_o/  \o_)( |
-          |/     /\     \|
-          (_     ^^     _)
-           \__|IIIIII|__/
-            | \IIIIII/ |
-            \          /
-             `--------`
-          ☠️ Privateerr ☠️
-  Adventure Awaits, Treasure Beckons!
-```
-
-🏝️ Cast yer pull requests ashore, or send a message in a bottle.
-
-<!-- markdownlint-disable-next-line MD036 -->
-_The sea calls, the code answers. Fair winds and full containers, matey! 🌊🏴‍☠️_
+Fair winds, private keys below deck, and no VPN-client identity crises. 🏴‍☠️

--- a/README.md
+++ b/README.md
@@ -13,30 +13,21 @@
 </p>
 
 <p align="center">
+  <img src="https://img.shields.io/badge/Dockerized-Brig-2496ED?logo=docker&amp;logoColor=white" alt="Dockerized brig" />
+  <img src="https://img.shields.io/badge/Cloaked-by%20PIA%20%26%20WireGuard-2EA44F?logo=wireguard&amp;logoColor=white" alt="Cloaked by PIA and WireGuard" />
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=Legal%20Scroll&amp;color=1677B8" alt="Legal Scroll: Apache 2.0 license" /></a>
+</p>
+
+<p align="center">
   <a href="https://github.com/scottgigawatt/privateerr/releases/latest"><img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Latest%20Treasure%20Map&amp;logo=github&amp;color=1677B8" alt="Latest Privateerr release" /></a>
-  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/github/actions/workflow/status/scottgigawatt/privateerr/build-and-push.yml?branch=main&amp;label=Privateerr%20build&amp;logo=githubactions&amp;logoColor=white" alt="Privateerr build status on main" /></a>
+  <img src="https://img.shields.io/badge/Battle--Tested-Synology%20%7C%20macOS-1677B8" alt="Battle-tested on Synology and macOS" />
   <a href="https://www.bestpractices.dev/projects/13442"><img src="https://www.bestpractices.dev/projects/13442/badge" alt="OpenSSF Best Practices badge" /></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/badge/Scanned-Trivy%20Bilge%20Check-008B8B?logo=aqua&amp;logoColor=white" alt="Container images scanned with Trivy" /></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=Legal%20Scroll&amp;color=1677B8" alt="Legal Scroll: Apache 2.0 license" /></a>
-  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/GHCR-Privateerr%20Captain-1677B8?logo=github&amp;logoColor=white" alt="Privateerr image on GitHub Container Registry" /></a>
-  <a href="https://hub.docker.com/r/scottgigawatt/privateerr"><img src="https://img.shields.io/docker/pulls/scottgigawatt/privateerr?label=Docker%20Hub%20Privateerr&amp;logo=docker&amp;color=1677B8" alt="Privateerr pulls from Docker Hub" /></a>
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/Dockerized-Brig-2496ED?logo=docker&amp;logoColor=white" alt="Dockerized brig" />
-  <img src="https://img.shields.io/badge/Cloaked-by%20PIA%20%26%20WireGuard-2EA44F?logo=wireguard&amp;logoColor=white" alt="Cloaked by PIA and WireGuard" />
-  <a href="./docker/Dockerfile"><img src="https://img.shields.io/badge/Base-Alpine%20Pinned-0D597F?logo=alpinelinux&amp;logoColor=white" alt="Pinned Alpine base image" /></a>
-  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/Multi--Arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-1677B8?logo=docker&amp;logoColor=white" alt="Privateerr images for amd64, arm64, and arm/v7" /></a>
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/Battle--Tested-Synology%20%7C%20macOS-1677B8" alt="Battle-tested on Synology and macOS" />
-  <a href="https://github.com/scottgigawatt/privateerr/commits/main"><img src="https://img.shields.io/github/last-commit/scottgigawatt/privateerr?label=Last%20Raid&amp;logo=git&amp;color=2EA44F" alt="Date of the last commit to main" /></a>
-  <a href="https://github.com/scottgigawatt/privateerr"><img src="https://img.shields.io/github/repo-size/scottgigawatt/privateerr?label=Hold%20Capacity&amp;color=1677B8" alt="Privateerr repository size" /></a>
-  <img src="https://img.shields.io/badge/Rum%20Rations-Plentiful-E66A24" alt="Rum rations: Plentiful" />
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/github/actions/workflow/status/scottgigawatt/privateerr/build-and-push.yml?branch=main&amp;label=Privateerr%20build&amp;logo=githubactions&amp;logoColor=white" alt="Privateerr build status on main" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/Fleet-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-1677B8?logo=docker&amp;logoColor=white" alt="Privateerr images for amd64, arm64, and arm/v7" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/badge/Bilge%20Check-Trivy-1904DA?logo=aqua&amp;logoColor=white" alt="Container images scanned with Trivy" /></a>
 </p>
 
 <p align="center">─── ⛧ ───</p>

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Dockerized-Brig-2496ED?logo=docker&amp;logoColor=white" alt="Dockerized brig" />
   <img src="https://img.shields.io/badge/Cloaked-by%20PIA%20%26%20WireGuard-2EA44F?logo=wireguard&amp;logoColor=white" alt="Cloaked by PIA and WireGuard" />
-  <a href="./LICENSE"><img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=Legal%20Scroll&amp;color=1677B8" alt="Legal Scroll: Apache 2.0 license" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/scottgigawatt/privateerr?label=Legal%20Scroll&amp;color=8250DF" alt="Legal Scroll: Apache 2.0 license" /></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/scottgigawatt/privateerr/releases/latest"><img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Latest%20Treasure%20Map&amp;logo=github&amp;color=1677B8" alt="Latest Privateerr release" /></a>
-  <img src="https://img.shields.io/badge/Battle--Tested-Synology%20%7C%20macOS-1677B8" alt="Battle-tested on Synology and macOS" />
+  <a href="https://github.com/scottgigawatt/privateerr/releases/latest"><img src="https://img.shields.io/github/v/release/scottgigawatt/privateerr?label=Latest%20Treasure%20Map&amp;logo=github&amp;color=BE123C" alt="Latest Privateerr release" /></a>
+  <img src="https://img.shields.io/badge/Battle--Tested-Synology%20%7C%20macOS-0891B2" alt="Battle-tested on Synology and macOS" />
   <a href="https://www.bestpractices.dev/projects/13442"><img src="https://www.bestpractices.dev/projects/13442/badge" alt="OpenSSF Best Practices badge" /></a>
 </p>
 
 <p align="center">
   <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/github/actions/workflow/status/scottgigawatt/privateerr/build-and-push.yml?branch=main&amp;label=Privateerr%20build&amp;logo=githubactions&amp;logoColor=white" alt="Privateerr build status on main" /></a>
-  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/Fleet-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-1677B8?logo=docker&amp;logoColor=white" alt="Privateerr images for amd64, arm64, and arm/v7" /></a>
-  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/badge/Bilge%20Check-Trivy-1904DA?logo=aqua&amp;logoColor=white" alt="Container images scanned with Trivy" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/pkgs/container/privateerr"><img src="https://img.shields.io/badge/Fleet-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-6D28D9?logo=docker&amp;logoColor=white" alt="Privateerr images for amd64, arm64, and arm/v7" /></a>
+  <a href="https://github.com/scottgigawatt/privateerr/actions/workflows/build-and-push.yml"><img src="https://img.shields.io/badge/Bilge%20Check-Trivy-BE185D?logo=aqua&amp;logoColor=white" alt="Container images scanned with Trivy" /></a>
 </p>
 
 <p align="center">─── ⛧ ───</p>

--- a/config/README.md
+++ b/config/README.md
@@ -1,38 +1,17 @@
-# Config Directory
+# Privateerr configuration ⚓
 
-Ahoy, matey! This be the config hold for the full Privateerr stack.
+This directory holds persistent and generated state for the local Privateerr, Gluetun, and Buccaneerr Compose services. Each subdirectory documents its owner and retention rules.
 
-## Purpose
-
-> [!NOTE]
->
-> 🏴‍☠️ Each service gets its own berth under this directory. Gluetun's berth carries the WireGuard map because both Privateerr and Gluetun need to touch it.
-
-The important live files sit here:
+Privateerr replaces these shared files whenever it generates a connection:
 
 ```text
 config/gluetun/wireguard/wg0.conf
 config/gluetun/wireguard/privateerr.env
 ```
 
-Privateerr overwrites both files when it runs. The checked-in versions are example maps only, safe for the ship's log. If ye run a live test, `make clean-test` or `make restore-test-config` restores the example copies from `test/examples/example-wg0.conf` and `test/examples/example-privateerr.env`.
+The checked-in files contain example data. `privateerr.env` supplies `PIA_WG_SERVER_NAME`; the Gluetun wrapper exports that value as `SERVER_NAMES` before it starts Gluetun.
 
-`privateerr.env` carries the Gluetun metadata scroll. The shiniest coin in that scroll be `PIA_WG_SERVER_NAME`; the Gluetun wrapper reads it, exports `SERVER_NAMES`, and then starts Gluetun proper.
+Use `make run-privateerr` to generate fresh files, `make test-e2e` to validate the complete voyage, and `make restore-test-config` before committing.
 
-## Instructions
-
-> [!TIP]
->
-> 🦜 Before hoistin' anchor, make sure yer `.env` and Docker Compose file are ready to chart the right course.
-
-To use this directory:
-
-1. Run `make test-e2e` for the full validation voyage.
-2. Run `make run-privateerr` if ye only want fresh `wg0.conf` and `privateerr.env`.
-3. Run `make restore-test-config` before committing, lest live secrets sneak aboard.
-
-> [!IMPORTANT]
->
-> ⚓️ The example files are boring on purpose. Real VPN treasure belongs in yer runtime hold, not in git.
-
-Fair winds and following seas, me mateys! 🌊🏴‍☠️
+> [!WARNING]
+> Live WireGuard configuration, port-forwarding metadata, and logs can expose VPN details. Keep them out of Git and redact them from issues or chat.

--- a/config/buccaneerr/README.md
+++ b/config/buccaneerr/README.md
@@ -1,6 +1,6 @@
-# Buccaneerr Config Hold 🔎
+# Buccaneerr configuration 🔎
 
-Yo ho! This berth belongs to Buccaneerr, the test deckhand who checks whether the tunnel truly floats.
+Buccaneerr is the test-only deckhand that validates the running tunnel and writes its log here:
 
 Buccaneerr writes validation logs here:
 
@@ -8,9 +8,7 @@ Buccaneerr writes validation logs here:
 config/buccaneerr/logs/buccaneerr.log
 ```
 
-> [!NOTE]
->
-> 🧽 Those logs be ignored by git. They are useful after a voyage, but too full of fresh sea spray for the public ledger.
+The log is ignored by Git because it may contain fresh connection details.
 
 Buccaneerr checks:
 
@@ -19,6 +17,4 @@ Buccaneerr checks:
 - Gluetun reports healthy.
 - PIA port forwarding returns a proper port.
 
-> [!TIP]
->
-> 🦜 If the voyage sinks, start here first. Buccaneerr's log usually points straight at the busted plank.
+If the voyage sinks, inspect this log first; it usually points to the failed handoff.

--- a/config/gluetun/README.md
+++ b/config/gluetun/README.md
@@ -1,30 +1,23 @@
-# Gluetun Config Hold 🧭
+# Gluetun configuration 🧭
 
-Avast! This be Gluetun's berth, where the VPN tunnel keeps its charts, dock papers, and assorted salty scribbles.
+Privateerr and Gluetun both mount this directory. Privateerr generates the WireGuard configuration first, and Gluetun uses it to start the tunnel.
 
-> [!IMPORTANT]
->
-> 🏴‍☠️ Privateerr and Gluetun both mount this directory. Privateerr draws the WireGuard map first, then Gluetun follows that map into the tunnel.
-
-The two prized scrolls live here:
+The shared files live here:
 
 ```text
 config/gluetun/wireguard/wg0.conf
 config/gluetun/wireguard/privateerr.env
 ```
 
-> [!TIP]
->
-> 🦜 `privateerr.env` carries `PIA_WG_SERVER_NAME`. The wrapper turns that into Gluetun's `SERVER_NAMES` value so PIA port forwarding knows which dock to hail.
+`privateerr.env` carries `PIA_WG_SERVER_NAME`. The wrapper turns that into Gluetun's `SERVER_NAMES` value so PIA port forwarding requests the matching server.
 
-The wrapper script lives here too:
+The wrapper script also lives here:
 
 ```text
 config/gluetun/scripts/gluetun-entrypoint-wrapper.sh
 ```
 
-That wrapper waits for `privateerr.env`, grabs `PIA_WG_SERVER_NAME`, exports it as `SERVER_NAMES`, and then hands the wheel back to Gluetun's original entrypoint like a proper first mate.
+The wrapper waits for `privateerr.env`, exports `PIA_WG_SERVER_NAME` as `SERVER_NAMES`, and then hands control to Gluetun's original entrypoint.
 
-> [!NOTE]
->
-> ⚓ Runtime barnacles such as `forwarded_port`, `ip`, `piaportforward.json`, and Gluetun's server cache are ignored by git.
+> [!IMPORTANT]
+> Runtime files such as `forwarded_port`, `ip`, `piaportforward.json`, and Gluetun's server cache are ignored by Git. Treat the whole directory as sensitive state.

--- a/config/privateerr/README.md
+++ b/config/privateerr/README.md
@@ -1,18 +1,12 @@
-# Privateerr Config Hold 🏴‍☠️
+# Privateerr configuration 🏴‍☠️
 
-Ahoy! This berth belongs to Privateerr herself.
-
-Privateerr writes runtime logs here when she wakes, shakes the salt from her boots, and asks the official PIA scripts to draw a fresh WireGuard chart.
+Privateerr writes runtime logs to this directory while the official PIA scripts generate a WireGuard connection.
 
 ```text
 config/privateerr/logs/privateerr.log
 ```
 
-> [!NOTE]
->
-> 🧽 That log be ignored by git, because live credentials and fresh voyage details belong in yer local hold, not nailed to the public mast.
-
-The actual WireGuard treasure still lands in Gluetun's berth:
+The log is ignored by Git because it can contain live connection details. The generated WireGuard files land in Gluetun's shared directory:
 
 ```text
 config/gluetun/wireguard/wg0.conf
@@ -20,5 +14,4 @@ config/gluetun/wireguard/privateerr.env
 ```
 
 > [!CAUTION]
->
-> 💣 Live `wg0.conf` and `privateerr.env` can contain sensitive voyage details. Run `make restore-test-config` before committing.
+> Live `wg0.conf` and `privateerr.env` can contain sensitive connection details. Run `make restore-test-config` before committing.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,47 +1,61 @@
-# Keep to the Code 📜🏴‍☠️
+# Code of conduct 📜🏴‍☠️
 
-This be Privateerr's code of conduct. Around here, the Code be more than guidelines. It be the map, the compass, and the plank avoidin' manual.
+Privateerr welcomes contributors and users of every experience level. Keep the pirate jokes light, the technical disagreements factual, and every person on deck treated with dignity.
 
-## The Articles ⚓
+## Our pledge
 
-All hands aboard this repository agree to:
+We pledge to make participation in this project and its community free from harassment for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, experience level, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, sexual identity and orientation, or any other protected or personal characteristic.
 
-- Treat other sailors with respect, patience, and good faith.
-- Welcome bug reports, questions, pull requests, and tiny cursed config discoveries.
-- Keep disagreements focused on code, docs, behavior, and reproducible facts.
-- Help protect secrets, credentials, generated WireGuard files, and private logs.
-- Remember that everyone starts somewhere, even if that somewhere be face-down in Docker Compose YAML.
+## Expected behavior
 
-## Mutiny Most Foul ☠️
+Community members should:
 
-The following gets tossed overboard:
+- Treat people with respect, patience, and good faith.
+- Give and accept constructive technical feedback.
+- Focus disagreements on observable behavior, code, documentation, and reproducible evidence.
+- Respect privacy and redact credentials, generated WireGuard configuration, private logs, and personal information.
+- Accept responsibility, apologize when appropriate, and learn from mistakes.
+- Consider the needs of the wider community, not only individual preferences.
 
-- Harassment, insults, slurs, threats, stalking, or unwanted attention.
-- Publicly posting private data, secrets, credentials, tokens, or generated VPN configs.
-- Deliberately wasting maintainer time with spam, bad-faith arguments, or cursed nonsense.
-- Turning technical disagreement into personal cannon fire.
-- Encouraging unsafe changes that would expose users, credentials, or networks.
+## Unacceptable behavior
 
-## Keep Yer Secrets Below Deck 🧭
+The following behavior is not welcome:
 
-Privateerr touches VPN credentials and generated WireGuard config. Do not post real:
+- Harassment, insults, slurs, threats, stalking, intimidation, or unwanted attention.
+- Sexualized language or imagery, unwelcome advances, or attacks involving identity or personal characteristics.
+- Publishing another person's private information without explicit permission.
+- Posting credentials, tokens, private keys, generated secrets, or sensitive logs.
+- Sustained disruption, spam, trolling, or bad-faith demands on maintainers and contributors.
+- Retaliation against someone who reports a concern in good faith.
+- Encouraging changes that knowingly expose users, credentials, systems, or networks.
 
-- PIA usernames or passwords.
-- WireGuard private keys.
-- Full `wg0.conf` files.
-- Live `privateerr.env` files.
-- Container logs that contain secrets or network details ye would rather not hand to strangers.
+## Scope
 
-> [!WARNING]
->
-> 🧨 If ye find a security problem, do not open a public issue with exploit details. Follow the [security policy](SECURITY.md) and keep the cursed treasure map private.
+This Code applies in the Privateerr repository, issue tracker, pull requests, discussions, project Discord spaces, and other public or private spaces where someone is representing the project or its community.
 
-## Enforcement 🪝
+## Report conduct concerns
 
-I, the mostly solo captain of this tiny vessel, may remove comments, close issues, lock threads, block users, or refuse contributions that break the Code.
+The repository owner is responsible for clarifying and enforcing this Code.
 
-This is not a court of pirate law with powdered wigs and dramatic candles. It is a small open source repo. Be decent, be clear, and the seas stay friendly.
+For a public, non-sensitive moderation concern, report the relevant GitHub content using GitHub's reporting tools or open a brief issue that links to the affected public content. For a concern involving private information, request a private conversation with the repository owner or a HADES moderator without posting the details publicly.
 
-## Attribution 📚
+Conduct reports will be reviewed as promptly and impartially as practical. Information will be shared only as needed to investigate and respond, subject to platform limitations and legal obligations. Retaliation against a good-faith reporter is itself a violation.
 
-This code of conduct is custom for Privateerr, inspired by the general spirit of healthy open source communities and the ancient wisdom: keep to the Code, lest ye meet the plank.
+Security vulnerabilities follow the separate [security policy](SECURITY.md). General usage questions follow the [support guide](SUPPORT.md).
+
+## Enforcement
+
+Depending on severity, context, and prior behavior, maintainers may:
+
+1. Ask for a correction and explain the impact of the behavior.
+2. Remove or edit content and issue a formal warning.
+3. Temporarily restrict participation.
+4. Permanently block participation and report serious abuse to the relevant platform.
+
+Maintainers may reject contributions, lock conversations, or take immediate protective action when delay would expose people or systems to harm.
+
+## Attribution
+
+This project-specific Code draws on the structure and community principles of the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). Privateerr remains responsible for applying and enforcing its own policy.
+
+Be decent, protect the crew, and keep the cannon fire pointed at reproducible bugs. 🏴‍☠️

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,14 +2,15 @@
 
 Ahoy, improbable contributor. Since this project will likely be maintained by one caffeine-powered captain yelling at Docker Compose in the moonlight, contributions be welcome but should arrive shipshape.
 
-## Before Ye Start ⚓
+## Before you start ⚓
 
 - Read the [README](../README.md).
 - Read the [security policy](SECURITY.md) before sharing logs or generated config.
+- Read the [documentation style](documentation-style.md) before changing public Markdown.
 - Keep to the [Code](CODE_OF_CONDUCT.md).
 - Check existing issues before opening a duplicate treasure map.
 
-## What Belongs Here 🧭
+## What belongs here 🧭
 
 Good contributions include:
 
@@ -26,7 +27,7 @@ Questionable cargo includes:
 - Changes to upstream PIA scripts inside `docker/pia-manual-connections`.
 - Anything that requires committing secrets, live `wg0.conf`, or real `privateerr.env` data.
 
-## Local Setup 🛠️
+## Set up a development checkout 🛠️
 
 ```sh
 git clone --recurse-submodules git@github.com:scottgigawatt/privateerr.git
@@ -49,19 +50,16 @@ make clean-test
 pre-commit run --all-files
 ```
 
-`make down` preserves volumes and images. `make clean` never touches Docker,
-`.env`, generated WireGuard state, config, or backups. Use `make nuke` only for
-an intentionally destructive reset of this repository's Docker resources and
-scoped Buildx cache; it still preserves `.env`, `backups/`, and persistent
-config before restoring the checked-in examples.
+`make down` preserves volumes and images. `make clean` never touches Docker, `.env`, generated WireGuard state, config, or backups. Use `make nuke` only for an intentionally destructive reset of this repository's Docker resources and scoped Buildx cache; it still preserves `.env`, `backups/`, and persistent config before restoring the checked-in examples.
 
 > [!IMPORTANT]
 >
 > 🧪 `make test-e2e` uses real PIA credentials from `.env`. That voyage should happen locally, not with secrets flung into random public waters.
 
-## Style Rules 📜
+## Follow the project style 📜
 
-- Public Markdown and user-facing command output may speak fluent pirate.
+- Public Markdown and user-facing command output may use light pirate flavor after the operational meaning is clear.
+- Documentation follows [`documentation-style.md`](documentation-style.md), including sentence-case headings and alert limits.
 - Code comments should use plain English.
 - Shell scripts written for host use should use `#!/bin/sh` where possible.
 - Shell scripts should use four spaces for indentation.
@@ -73,22 +71,13 @@ config before restoring the checked-in examples.
 - Keep service config directories aligned with service names.
 - Leave upstream PIA scripts untouched so users can verify the treasure scrolls were not tampered with.
 
-### Editor Tooling 🧰
+### Configure editor tooling 🧰
 
-`.editorconfig` is the portable source of truth for indentation, line endings,
-final newlines, and trailing whitespace. Install the recommendations from
-`.vscode/extensions.json` when using VS Code; each entry carries an aligned
-comment explaining whether it formats, validates, or only highlights a file
-type.
+`.editorconfig` is the portable source of truth for indentation, line endings, final newlines, and trailing whitespace. Install the recommendations from `.vscode/extensions.json` when using VS Code; each entry carries an aligned comment explaining whether it formats, validates, or only highlights a file type.
 
-Workspace format-on-save is deliberately disabled. Prettier is available only
-for explicit formatting of supported JSON and Markdown files through the
-checked-in `.prettierrc.json5`. It does not parse jq, and the repository excludes
-jq, YAML, TOML, and aligned workspace JSONC from Prettier so specialized tools
-cannot undo project-owned spacing. Keep two spaces before pinned-action
-comments in workflow YAML.
+Workspace format-on-save is deliberately disabled. Prettier is available only for explicit formatting of supported JSON and Markdown files through the checked-in `.prettierrc.json5`. It does not parse jq, and the repository excludes jq, YAML, TOML, and aligned workspace JSONC from Prettier so specialized tools cannot undo project-owned spacing. Keep two spaces before pinned-action comments in workflow YAML.
 
-## Release Tags 🏷️
+## Create release tags 🏷️
 
 - Create annotated release tags from commits already on `main`.
 - Use semantic versions such as `v1.2.3` or `v1.2.3-rc.1`.
@@ -99,7 +88,7 @@ comments in workflow YAML.
 - Prerelease tags publish only the prerelease version and commit SHA tags.
 - Wait for the image workflow, registry mirror, and provenance checks before publishing the GitHub release.
 
-## Pull Requests 🪝
+## Prepare a pull request 🪝
 
 Before opening a pull request:
 
@@ -113,8 +102,8 @@ Before opening a pull request:
 
 Tiny pull requests be easier to review than a kraken-sized rewrite with six unrelated tentacles.
 
-## Security Reports 🛡️
+## Report security concerns 🛡️
 
-Do not report security problems in public issues or pull requests. Use the [security policy](SECURITY.md), or hail the captain in [🔥HADES🔥](https://discord.gg/BpEGzWwGYf) Discord for a safer channel.
+Do not report security problems in public issues, pull requests, or Discord. Use the [security policy](SECURITY.md) and GitHub private vulnerability reporting. Use the [support guide](SUPPORT.md) for non-sensitive questions.
 
 Fair winds, clean diffs, and may yer YAML indent on the first try. ☠️

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,8 +1,8 @@
-# Security Policy 🛡️🏴‍☠️
+# Security policy 🛡️🏴‍☠️
 
 Ahoy, security-minded sailor. If ye spot a cursed leak, a leaky hull, or a suspicious barnacle clingin' to Privateerr, this be the proper chart for reportin' it.
 
-## Supported Versions ⚓
+## Supported versions ⚓
 
 Privateerr sails by the stable `latest` image and the `edge` image built from `main`. Since this project be a small vessel, security fixes target those newest charts instead of older treasure maps.
 
@@ -17,7 +17,7 @@ Privateerr sails by the stable `latest` image and the `edge` image built from `m
 >
 > 🧭 Privateerr uses the official PIA manual connection scripts as a submodule. Security issues in those upstream scripts should also be reported to the PIA project, because Privateerr keeps those scrolls untouched.
 
-## Reporting a Vulnerability 🦜
+## Report a vulnerability 🦜
 
 Please do not open a public GitHub issue for secrets, credential leaks, auth bypasses, or anything that could help another scallywag attack a user.
 
@@ -27,11 +27,11 @@ Report vulnerabilities using GitHub's private vulnerability reporting feature:
 2. Choose **Report a vulnerability**.
 3. Include clear steps to reproduce, affected files, logs, container tags, and any relevant Docker Compose settings.
 
-Ye can also send a message through the [🔥HADES🔥](https://discord.gg/BpEGzWwGYf) Discord server if ye need to hail the captain quickly.
+Do not send vulnerability details through Discord, discussions, issues, or pull requests. Those routes are for non-sensitive support and public collaboration.
 
-If private vulnerability reporting is unavailable, open a GitHub issue with only a brief non-sensitive note asking for a secure reporting channel, or use Discord to ask where to send details. Keep the dangerous details off the public deck.
+If private vulnerability reporting is unavailable, open a GitHub issue containing only a brief, non-sensitive request for a private reporting channel. Do not describe the vulnerability publicly.
 
-## What to Include 📜
+## Include useful evidence 📜
 
 Helpful reports include:
 
@@ -45,7 +45,7 @@ Helpful reports include:
 >
 > 💣 Never include real PIA usernames, passwords, WireGuard private keys, generated `wg0.conf` files, or live `privateerr.env` metadata in a public report.
 
-## Response Expectations 🕰️
+## Understand response expectations 🕰️
 
 This be a small maintainer ship, not a giant navy. I will do my best to:
 
@@ -57,7 +57,7 @@ This be a small maintainer ship, not a giant navy. I will do my best to:
 
 If a report is declined, I will try to explain why without leakin' dangerous details into open waters.
 
-## Container Image Security 🔎
+## Understand container image security 🔎
 
 Privateerr images are built from pinned Alpine image digests, not floating `latest` bases. GitHub Actions are pinned to full commit SHAs for the same reason: the same source commit should build from the same known cargo unless a dependency update is reviewed and merged.
 
@@ -78,5 +78,7 @@ Rebuilding the same commit does not automatically pick up a newer Alpine base. T
 > [!TIP]
 >
 > 🏴‍☠️ Pull `latest` for the newest stable patched hull. Pull `edge` only when ye intentionally want the newest successful `main` build.
+
+Use the [support guide](SUPPORT.md) for non-sensitive setup questions and reproducible bugs.
 
 Fair winds, sharp eyes, and may yer secrets stay below deck. ☠️

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,31 @@
+# Support 🛟
+
+Choose the route that matches what you need so questions, defects, and security reports reach the right deck.
+
+## Ask a usage question
+
+Use the [🔥HADES🔥 Discord server](https://discord.gg/BpEGzWwGYf) for setup questions, Compose planning, and informal troubleshooting. Describe the image tag, host platform, command you ran, and whether you are generating files only or starting the Gluetun stack.
+
+Redact PIA credentials, WireGuard keys, live `wg0.conf`, live `privateerr.env`, forwarded ports, private URLs, and sensitive logs before sharing anything.
+
+## Report a reproducible bug
+
+Open a [Privateerr bug report](https://github.com/scottgigawatt/privateerr/issues/new?template=bug-report.md) when current source or a published image behaves incorrectly.
+
+Include:
+
+- The Privateerr, Gluetun, and Buccaneerr image tags involved.
+- Your operating system, Docker version, and Docker Compose version.
+- The exact command and a minimal reproduction.
+- Whether `make config` succeeds.
+- Sanitized logs or output.
+
+## Request a documentation improvement
+
+Open a [documentation request](https://github.com/scottgigawatt/privateerr/issues/new?template=documentation-enhancement.md) and identify the page, heading, command, or example that is unclear.
+
+## Report a vulnerability
+
+Do not use Discord or a public issue for vulnerability details. Follow the [security policy](SECURITY.md) and use GitHub private vulnerability reporting.
+
+Privateerr is maintained by a small crew, so support is best effort. Clear reproductions and sanitized evidence make a safe answer much easier to chart.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,8 +1,8 @@
-# 🧭 Advanced Usage
+# Advanced usage 🧭
 
 The main README stays focused on the shortest path: generate `wg0.conf`, inspect `privateerr.env`, and move on with your day. This page keeps the deeper project details.
 
-## 🧪 Full Stack Validation
+## Run full-stack validation 🧪
 
 Privateerr includes an end-to-end Compose test path:
 
@@ -21,9 +21,7 @@ make test-e2e
 >
 > The e2e test uses **real PIA credentials** from `.env`. Fake credentials should fail, and live generated VPN files should not be committed.
 
-Before Privateerr starts, Make asks Docker Compose for the resolved environment
-and checks only `PIA_USER` and `PIA_PASS`. The preflight never sources `.env` or
-prints either value, and it rejects the documented examples before a live run.
+Before Privateerr starts, Make asks Docker Compose for the resolved environment and checks only `PIA_USER` and `PIA_PASS`. The preflight never sources `.env` or prints either value, and it rejects the documented examples before a live run.
 
 If the test stack is running and you want to clear it:
 
@@ -31,7 +29,7 @@ If the test stack is running and you want to clear it:
 make clean-test
 ```
 
-## 🏗️ Multi-Architecture Builds
+## Build multiple architectures 🏗️
 
 Published images target:
 
@@ -59,7 +57,7 @@ Override it for one-off checks:
 make build-platforms BUILDX_PLATFORM_OPTIONS="--platform linux/amd64,linux/arm64"
 ```
 
-## 📦 Registry Publishing
+## Understand registry publishing 📦
 
 The `build-and-push` GitHub Actions workflow builds and publishes Privateerr to GHCR first, then mirrors the same multi-architecture image to Docker Hub with Skopeo.
 
@@ -106,9 +104,9 @@ Configure these GitHub Actions values before enabling Docker Hub publishing:
 | Secret  | `DOCKERHUB_USERNAME` | Docker Hub username used to log in.             |
 | Secret  | `DOCKERHUB_TOKEN`    | Docker Hub access token used by GitHub Actions. |
 
-The Docker Hub repository overview is updated by the same workflow from [DOCKERHUB_README.md](./DOCKERHUB_README.md). Keep that file shorter than the GitHub README: Docker Hub readers usually need to know what the image does, how to pull it, what platforms it supports, and where the full project docs live.
+The Docker Hub repository overview is updated by the same workflow from [`docker-hub-description.md`](docker-hub-description.md). Keep that file shorter than the GitHub README: Docker Hub readers usually need to know what the image does, how to pull it, what platforms it supports, and where the full project documentation lives.
 
-## 🧷 Pinned Build Inputs
+## Maintain pinned build inputs 🧷
 
 The release workflow uses pinned GitHub Action SHAs and a pinned Alpine image digest. That makes release builds boring in the best way: the same source commit should use the same action code and base image bits every time.
 
@@ -119,17 +117,13 @@ Renovate keeps those pins from going stale. It tracks:
 - Compose image references.
 - Git submodules.
 
-When Renovate opens a dependency PR, the validation workflow checks that every
-digest-pinned build dependency matches across Dockerfiles, workflow build args,
-and the example environment file. If one build arg drifts away from the fleet,
-[check-build-pin-policy.sh](../test/policy/check-build-pin-policy.sh) fails
-before the PR can merge.
+When Renovate opens a dependency pull request, the validation workflow checks that every digest-pinned build dependency matches across Dockerfiles, workflow build arguments, and the example environment file. If one build argument drifts away from the fleet, [`check-build-pin-policy.sh`](../test/policy/check-build-pin-policy.sh) fails before the pull request can merge.
 
 > [!NOTE]
 >
 > 🧭 `latest` remains the recommended stable image tag for users, while `edge` follows successful `main` builds. Neither tag is used as the Alpine base. The base image is intentionally pinned and moved by reviewed Renovate PRs.
 
-## 🛠️ Useful Maintenance Commands
+## Use maintenance commands 🛠️
 
 | ⚙️ Command              | ✅ Purpose                                                             |
 | ----------------------- | ---------------------------------------------------------------------- |
@@ -150,11 +144,9 @@ before the PR can merge.
 | `make clean-test`       | Stop the live test stack and restore checked-in examples.              |
 | `make nuke`             | Remove project Docker resources/cache and reset transient test state.  |
 
-`make nuke` preserves `.env`, `backups/`, and persistent bind-mounted config.
-Base-image removal is best-effort when another container or project still uses
-the same image.
+`make nuke` preserves `.env`, `backups/`, and persistent bind-mounted config. Base-image removal is best effort when another container or project still uses the same image.
 
-## 📄 Generated Files
+## Restore generated files 📄
 
 Privateerr overwrites these files when it runs:
 

--- a/docs/docker-hub-description.md
+++ b/docs/docker-hub-description.md
@@ -1,12 +1,12 @@
-# ⚓ Privateerr
+# Privateerr ⚓
 
 Privateerr is a tiny Docker wrapper that packages the original, unmodified [pia-foss/manual-connections](https://github.com/pia-foss/manual-connections) scripts from Private Internet Access (PIA).
 
 > [!IMPORTANT]
 >
-> ⚠️ Privateerr is not a VPN client!️️ ⚠️  It generates a PIA WireGuard config file and a small Gluetun port forwarding metadata file, then gets out of the way.
+> Privateerr is not a VPN client. It generates a PIA WireGuard configuration file and a small Gluetun port-forwarding metadata file, then exits.
 
-## 📦 Images
+## Pull an image 📦
 
 ```sh
 docker pull scottgigawatt/privateerr:latest
@@ -28,8 +28,7 @@ docker pull scottgigawatt/privateerr:edge
 | `sha-cfa2fb5` | Image built from a specific source commit.                          |
 
 Major version zero omits the broad `0` alias. Prerelease versions keep only their own version and commit tags, never replacing movable stable aliases.
-Release publication accepts only `v`-prefixed annotated SemVer tags whose
-commits already belong to `main`.
+Release publication accepts only `v`-prefixed annotated SemVer tags whose commits already belong to `main`.
 
 Published tags are multi-architecture manifests for:
 
@@ -43,15 +42,20 @@ Docker should pull the right image for your host automatically.
 
 Images are built from pinned Alpine digests and scanned before publishing. Dependency updates land through Renovate PRs first, so a rebuild of the same source commit does not silently drift to a new base image.
 
-## ⚡ Fastest Path
+## Generate configuration ⚡
 
-Most users should use the GitHub repo because it includes the Compose file, Makefile, example env file, and mounted config directories:
+Most users should use the GitHub repository because it includes the Compose file, Makefile, example environment file, and mounted config directories:
 
 ```sh
 git clone --recurse-submodules https://github.com/scottgigawatt/privateerr.git
 cd privateerr
 cp example.env .env
-PIA_USER="p1234567" PIA_PASS="p0rtRoya1" PIA_PF="false" make run-privateerr
+```
+
+Set `PIA_USER`, `PIA_PASS`, and `PIA_PF` in the ignored `.env` file, then generate the files:
+
+```sh
+make run-privateerr
 ```
 
 That writes:
@@ -63,9 +67,9 @@ That writes:
 
 > [!WARNING]
 >
-> 🚨 Keep wg0.conf private! 🚨  It contains VPN connection material.
+> Keep live `wg0.conf` and `privateerr.env` files private. They can contain VPN connection material and deployment-specific metadata.
 
-## 🧭 Why Pair It With Gluetun?
+## Pair Privateerr with Gluetun 🧭
 
 Gluetun is a real VPN client. Privateerr is a VPN config generator.
 
@@ -73,10 +77,10 @@ The simple use case is: generate `wg0.conf`, copy it into the VPN client you alr
 
 The powerful use case is: run Privateerr and Gluetun together in Docker Compose. Privateerr writes the WireGuard config plus `PIA_WG_SERVER_NAME`; the included Gluetun wrapper reads that server name, exports it as `SERVER_NAMES`, and Gluetun starts with the right PIA WireGuard server for port forwarding.
 
-## 🔗 Links
+## Continue with the full documentation 🔗
 
 | 📚 Resource | 🔎 Link                                                                       |
 | ----------- | ----------------------------------------------------------------------------- |
-| GitHub repo | [scottgigawatt/privateerr](https://github.com/scottgigawatt/privateerr)       |
+| GitHub repository | [scottgigawatt/privateerr](https://github.com/scottgigawatt/privateerr)       |
 | PIA scripts | [pia-foss/manual-connections](https://github.com/pia-foss/manual-connections) |
 | Gluetun     | [qdm12/gluetun](https://github.com/qdm12/gluetun)                             |

--- a/docs/docker-hub-description.md
+++ b/docs/docker-hub-description.md
@@ -71,7 +71,7 @@ That writes:
 
 ## Pair Privateerr with Gluetun 🧭
 
-Gluetun is a real VPN client. Privateerr is a VPN config generator.
+Gluetun is a real VPN client. Privateerr generates PIA WireGuard configuration and server metadata for that client.
 
 The simple use case is: generate `wg0.conf`, copy it into the VPN client you already use, and leave.
 

--- a/docs/documentation-style.md
+++ b/docs/documentation-style.md
@@ -1,0 +1,87 @@
+# Documentation style ✍️
+
+Privateerr documentation should help readers complete a task or understand a boundary without making them decode the theme first. Keep the operational meaning plain and let the pirate voice add a little character around it.
+
+## Start with the reader
+
+Before writing, identify the audience and the one or two outcomes the page must deliver. Put prerequisites before procedures, order steps as readers perform them, and move optional detail after the main path.
+
+Use these content shapes:
+
+- **Concept:** Explain what something is, why it exists, and when it matters.
+- **Quickstart:** Give the shortest safe route to a useful result.
+- **How-to:** State the outcome, list prerequisites, provide numbered steps, verify the result, and cover likely failures.
+- **Reference:** Present facts for lookup with consistent headings, lists, or genuinely comparative tables.
+- **Troubleshooting:** Name the symptom, explain the cause when known, and give a verifiable recovery path.
+
+## Write plainly first
+
+- Use active voice and address the reader as **you** in procedures.
+- Put one main idea in each sentence and paragraph.
+- Lead with the conclusion or required action, then explain why.
+- Use the exact names shown in commands, files, services, and user interfaces.
+- Spell out an unfamiliar abbreviation on first use.
+- Keep ordinary prose paragraphs on one physical source line and use visual editor wrapping.
+
+Pirate language belongs in short introductions, transitions, and sign-offs. Commands, paths, warnings, security guidance, destructive actions, and troubleshooting instructions stay literal. A joke should never carry operational meaning.
+
+## Make headings searchable
+
+Use sentence case and put the useful keyword first. Emoji may follow a heading as decoration, but it must not replace a word or warning.
+
+- Prefer `## Generate a WireGuard configuration ⚡` over `## Fastest Path`.
+- Prefer `## Inspect environment values 🔎` over `## Inspect The Knobs`.
+- Do not skip heading levels.
+- Introduce a section before adding a subsection.
+
+## Format for the task
+
+- Use numbered lists for procedures and bullets for unordered choices.
+- Use tables only when readers need to compare multiple attributes.
+- Keep commands in `sh` fences without prompt characters or comments.
+- Put terminal transcripts in `console` fences and non-executable output in `text` fences.
+- Use uppercase kebab-case placeholders such as `YOUR-REGION` and explain what replaces them.
+- Use descriptive link text and relative links for repository-owned pages.
+- Link to the most specific useful upstream page instead of a generic home page.
+
+## Reserve alerts for critical information
+
+GitHub alerts are for information readers must notice while scanning. Most pages should need no more than one or two.
+
+- `[!NOTE]` adds useful context.
+- `[!TIP]` makes a task easier.
+- `[!IMPORTANT]` states information required for success.
+- `[!WARNING]` calls for immediate attention.
+- `[!CAUTION]` describes a risk or destructive outcome.
+
+Do not wrap routine commands in alerts. Do not place alerts back to back. Keep required actions and risk descriptions in the alert itself.
+
+## Use advanced Markdown deliberately
+
+- Use `<details>` only for optional sample output or lengthy diagnostics. Never hide prerequisites, primary steps, or risks.
+- Use footnotes only for tangential provenance or context. Essential information stays inline.
+- Use Mermaid when a relationship or sequence is materially clearer as a diagram. Provide adjacent prose that communicates the same information.
+- Keep task lists in issue and pull request templates. Static procedures use numbered steps.
+
+## Name files consistently
+
+Keep GitHub and project convention files in their established form, including `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `SUPPORT.md`. Name ordinary articles with lowercase kebab-case, such as `advanced-usage.md`.
+
+When renaming a page, update inbound Markdown links, workflow paths, scripts, and published descriptions in the same change.
+
+## Review the rendered result
+
+Before publishing documentation:
+
+1. Check commands, paths, defaults, and examples against the current source.
+2. Read the page in rendered GitHub Markdown.
+3. Verify diagrams, tables, alerts, anchors, and narrow-screen readability.
+4. Run `pre-commit run --all-files` and inspect `git diff --check`.
+5. Confirm no credentials, generated WireGuard state, private logs, or deployment-specific values entered the change.
+
+## Read the source guidance
+
+- [GitHub's basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+- [GitHub's advanced formatting guide](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting)
+- [GitHub's README guidance](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
+- [GitHub's contributor-guideline guidance](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,10 +1,8 @@
-# Privateerr Script Hold 🏴‍☠️
+# Privateerr script hold 🏴‍☠️
 
-These documented AWK programs and host helpers support the Privateerr Compose
-project. Pick the smallest tool for the job and review its header before running
-it against a live deployment.
+These documented AWK programs and host helpers support the Privateerr Compose project. Pick the smallest tool for the job and review its header before running it against a live deployment.
 
-## Script Chart 🧭
+## Find a script 🧭
 
 | Hold       | Script                                                                                                                               | Purpose                                                            |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
@@ -17,67 +15,43 @@ it against a live deployment.
 | 🐳 Compose | [`compose/nuke.sh`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/compose/nuke.sh)                               | Remove resources owned by one explicit Compose project             |
 | 🐳 Compose | [`compose/ps.sh`](https://github.com/scottgigawatt/privateerr/blob/main/scripts/compose/ps.sh)                                       | Print a compact status table for the Privateerr Compose project    |
 
-## AWK Programs 🧮
+## AWK programs 🧮
 
 ### `awk/collect-dockerfile-base-images.awk`
 
-Records global Dockerfile `ARG` defaults, resolves `${NAME}` and `$NAME` in
-`FROM`, ignores internal stages and `scratch`, and resets state between input
-files. Unresolved references are skipped instead of being passed to Docker.
-The nuke helper uses its unique output for best-effort declared-base cleanup.
+Records global Dockerfile `ARG` defaults, resolves `${NAME}` and `$NAME` in `FROM`, ignores internal stages and `scratch`, and resets state between input files. Unresolved references are skipped instead of being passed to Docker. The nuke helper uses its unique output for best-effort declared-base cleanup.
 
 ### `awk/format-compose-status.awk`
 
-Formats tab-separated `docker compose ps` data into aligned terminal columns,
-collapses equivalent IPv4 and IPv6 wildcard bindings, and places each distinct
-published port on its own continuation row. `compose/ps.sh` invokes it.
+Formats tab-separated `docker compose ps` data into aligned terminal columns, collapses equivalent IPv4 and IPv6 wildcard bindings, and places each distinct published port on its own continuation row. `compose/ps.sh` invokes it.
 
 ### `awk/order-environment.awk`
 
-Prints resolved Docker Compose environment assignments in the same order as
-`example.env`. `make env` invokes it through the centralized AWK variables.
+Prints resolved Docker Compose environment assignments in the same order as `example.env`. `make env` invokes it through the centralized AWK variables.
 
 ### `awk/strip-comments.awk`
 
-Removes comments, trailing whitespace, and empty lines. `make print-config` and
-`make print-env` share it so both raw views follow one filtering contract.
+Removes comments, trailing whitespace, and empty lines. `make print-config` and `make print-env` share it so both raw views follow one filtering contract.
 
-## Compose Helpers 🐳
+## Compose helpers 🐳
 
 ### `compose/backup.sh`
 
-Archives the complete `config/` directory with a timestamped filename. An
-incrementing suffix prevents a same-second backup from replacing an existing
-archive. `make backup` is the normal entry point, and `backups/` stays ignored.
+Archives the complete `config/` directory with a timestamped filename. An incrementing suffix prevents a same-second backup from replacing an existing archive. `make backup` is the normal entry point, and `backups/` stays ignored.
 
 ### `compose/check-pia-credentials.sh`
 
-Reads resolved Compose environment values from standard input and fails when a
-Privateerr deployment would start without real `PIA_USER` and `PIA_PASS`
-values. Invalid credentials produce a color-aware diagnostic with a corrective
-action; redirected output remains plain text and `NO_COLOR` disables terminal
-color. `make run-privateerr`, `make up`, and `make test-e2e` call it
-automatically.
+Reads resolved Compose environment values from standard input and fails when a Privateerr deployment would start without real `PIA_USER` and `PIA_PASS` values. Invalid credentials produce a color-aware diagnostic with a corrective action; redirected output remains plain text and `NO_COLOR` disables terminal color. `make run-privateerr`, `make up`, and `make test-e2e` call it automatically.
 
 ### `compose/nuke.sh`
 
-Validates the selected Compose model before deleting anything, captures service
-images, runs project-scoped teardown with volumes, orphans, and service images,
-then removes explicitly supplied local image references and one named Buildx
-builder. Repeated `--dockerfile` and `--additional-image` arguments avoid shell
-command evaluation. Declared base images are removed without force, so shared or
-in-use references are retained with a warning. Missing resources are harmless;
-unexpected Compose, Docker, or builder failures stop the helper.
+Validates the selected Compose model before deleting anything, captures service images, runs project-scoped teardown with volumes, orphans, and service images, then removes explicitly supplied local image references and one named Buildx builder. Repeated `--dockerfile` and `--additional-image` arguments avoid shell command evaluation. Declared base images are removed without force, so shared or in-use references are retained with a warning. Missing resources are harmless; unexpected Compose, Docker, or builder failures stop the helper.
 
-The helper never deletes repository files, `.env`, config, or backups. Make
-owns the later repository cleanup, transient-state reset, and example restore.
+The helper never deletes repository files, `.env`, config, or backups. Make owns the later repository cleanup, transient-state reset, and example restore.
 
 ### `compose/ps.sh`
 
-Resolves the Privateerr Compose project and prints only its containers in a
-terminal-friendly status table. Equivalent IPv4 and IPv6 wildcard bindings are
-collapsed, and each distinct published port receives an aligned continuation
-line. `make ps` is the normal entry point.
+Resolves the Privateerr Compose project and prints only its containers in a terminal-friendly status table. Equivalent IPv4 and IPv6 wildcard bindings are collapsed, and each distinct published port receives an aligned continuation line. `make ps` is the normal entry point.
 
 ```sh
 make backup
@@ -87,6 +61,4 @@ make test-make-helpers
 ```
 
 > [!IMPORTANT]
->
-> Keep credentials in the ignored `.env` file. Do not pass them as command-line
-> arguments, paste them into issues, or commit generated WireGuard state.
+> Keep credentials in the ignored `.env` file. Do not pass them as command-line arguments, paste them into issues, or commit generated WireGuard state.

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
-# Buccaneerr Test Hold 🧪🏴‍☠️
+# Buccaneerr test hold 🧪🏴‍☠️
 
 Welcome to the test hold, where Buccaneerr climbs aboard after Privateerr and Gluetun to make sure the whole WireGuard voyage did not spring a leak. ☠️
 
@@ -11,7 +11,7 @@ The test tree keeps responsibilities separate:
 - `examples/` stores the checked-in WireGuard and metadata examples restored after a live voyage.
 - the test-root `Dockerfile` and `buccaneerr-entrypoint.sh` remain the Buccaneerr build context.
 
-## Test Script Chart 🗺️
+## Find a test script 🗺️
 
 | Hold       | Script                                                                   | Purpose                                                            |
 | ---------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
@@ -26,25 +26,17 @@ The test tree keeps responsibilities separate:
 | 🎭 Stubs   | [`stubs/compose-docker-stub.sh`](stubs/compose-docker-stub.sh)           | Supply deterministic Docker output to Compose helper tests          |
 | 🎭 Stubs   | [`stubs/workflow-skopeo-stub.sh`](stubs/workflow-skopeo-stub.sh)         | Simulate registry inspection without network access                 |
 
-The subfolders separate static repository policy, reusable helper tests,
-deterministic command stubs, and checked-in reset examples. Make targets remain
-the public interface; invoke individual scripts only while diagnosing a focused
-failure.
+The subfolders separate static repository policy, reusable helper tests, deterministic command stubs, and checked-in reset examples. Make targets remain the public interface; invoke individual scripts only while diagnosing a focused failure.
 
-## Offline Policy and Helper Checks 🧭
+## Run offline policy and helper checks 🧭
 
-> [!TIP]
->
-> ```sh
-> make test
-> make test-make-helpers
-> make test-workflows
-> ```
+```sh
+make test
+make test-make-helpers
+make test-workflows
+```
 
-The complete local target checks reusable AWK and Compose helpers, config
-backups, release tags, every structured Discord profile, registry mirroring,
-synchronized SHA-256 build pins, and canonical image-tag channels. Disposable
-negative fixtures prove that mismatched pins and unsafe tag rules are rejected.
+The complete local target checks reusable AWK and Compose helpers, config backups, release tags, every structured Discord profile, registry mirroring, synchronized SHA-256 build pins, and canonical image-tag channels. Disposable negative fixtures prove that mismatched pins and unsafe tag rules are rejected.
 
 Run the opt-in live cleanup acceptance after changing Compose lifecycle or
 nuke behavior:
@@ -55,12 +47,9 @@ nuke behavior:
 > test/runtime/test-compose-cleanup-live.sh
 > ```
 
-It creates uniquely named disposable projects and unrelated sentinels on the
-real Docker daemon. The test proves `down` preserves volumes and images, then
-proves `nuke` removes only its project resources and named builder. It never
-uses the repository `.env`, config, backups, or PIA credentials.
+It creates uniquely named disposable projects and unrelated sentinels on the real Docker daemon. The test proves `down` preserves volumes and images, then proves `nuke` removes only its project resources and named builder. It never uses the repository `.env`, config, backups, or PIA credentials.
 
-## What Buccaneerr Be 🦜
+## Understand Buccaneerr 🦜
 
 Buccaneerr is the test-only image for this repo. It does not ship with the production Privateerr image, and it does not generate WireGuard config. Instead, it joins the running test stack after Privateerr has written its files and Gluetun has raised the VPN sails.
 
@@ -71,11 +60,9 @@ Buccaneerr checks the important loot:
 - PIA port forwarding produced a usable forwarded port.
 - The stack behaves like the downstream Synology-friendly Compose setup.
 
-> [!IMPORTANT]
->
-> ⚓ Buccaneerr exists so the main Privateerr image can stay wee, clean, and focused. Test tools like `curl` stay in this image instead of clutterin' the production brig.
+Buccaneerr keeps test tools such as `curl` out of the production Privateerr image, keeping that image wee and focused.
 
-## How It Gets Built 🛠️
+## Build and run Buccaneerr 🛠️
 
 The image is built from [Dockerfile](Dockerfile), using the same pinned Alpine base digest as Privateerr. The build copies [buccaneerr-entrypoint.sh](buccaneerr-entrypoint.sh) into the image and runs that script when the container starts.
 
@@ -92,10 +79,9 @@ make test-e2e
 ```
 
 > [!WARNING]
->
-> 🧨 The e2e voyage uses real PIA credentials from `.env`. Do not commit live credentials, generated VPN configs, or logs from yer secret treasure chest.
+> The end-to-end voyage uses real PIA credentials from `.env`. Do not commit live credentials, generated VPN configuration, or logs.
 
-## What It Does During E2E 🧭
+## Follow the end-to-end voyage 🧭
 
 The Compose stack starts Privateerr first. Privateerr writes:
 
@@ -106,7 +92,7 @@ Then Gluetun uses those files to start WireGuard and request PIA port forwarding
 
 If Buccaneerr exits cleanly, the ship be seaworthy. If it fails, check the service logs before blaming the sea monster in yer YAML.
 
-## Example Files 📜
+## Restore example files 📜
 
 The [examples](examples/) directory stores example files used to reset the repo after a test run:
 
@@ -123,11 +109,6 @@ make restore-test-config
 make nuke
 ```
 
-`clean-test` uses the volume-preserving `down` path and restores the examples.
-`nuke` additionally removes project containers, networks, volumes, images, and
-the `privateerr-local` Buildx cache, but it leaves `.env`, `backups/`, and the
-persistent config directory intact. Shared or in-use base images are retained.
+`clean-test` uses the volume-preserving `down` path and restores the examples. `nuke` additionally removes project containers, networks, volumes, images, and the `privateerr-local` Buildx cache, but it leaves `.env`, `backups/`, and the persistent config directory intact. Shared or in-use base images are retained.
 
-> [!TIP]
->
-> 🏴‍☠️ Run cleanup before committing after any real e2e voyage. Future ye will thank past ye for not smuggling secrets into the cargo hold.
+Run cleanup before committing after any real end-to-end voyage. Future ye will thank past ye for not smuggling secrets into the cargo hold. 🏴‍☠️


### PR DESCRIPTION
## Summary

This gives Privateerr a clearer chart from PIA credentials to Gluetun without making readers fight a kraken made of prose. ✨🏴‍☠️

- Rebuild the root README around a safe `.env` quickstart, an explicit Privateerr/Gluetun boundary, image channels, maintenance commands, and support routes.
- Add a Mermaid data-flow diagram and collapse only optional example output.
- Add a canonical documentation style guide and support policy grounded in official GitHub writing guidance.
- Strengthen contribution, security, and conduct guidance while keeping credential and vulnerability instructions literal.
- Standardize sentence-case headings, command fences, alert use, physical prose lines, and the light pirate voice across advanced, config, script, and test documentation.
- Update Docker Hub publication workflow paths.

## Filename policy and route changes

GitHub discovery files retain their conventional uppercase names: `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, and `AGENTS.md`. Ordinary articles use lowercase kebab-case.

- `docs/ADVANCED_USAGE.md` becomes `docs/advanced-usage.md`.
- `docs/DOCKERHUB_README.md` becomes `docs/docker-hub-description.md`.

Every repository reference, workflow trigger, and Docker Hub input was swept and updated in the same PR.

## Markdown choices

- Use GitHub alerts only for critical success or risk information, generally one or two per article.
- Use Mermaid where the VPN handoff is clearer as a flow.
- Use `<details>` only for optional example output.
- Keep footnotes available for tangential provenance, but do not hide operational or security guidance in them.
- Keep task lists in issue and pull request templates rather than static procedures.

## Validation

- `pre-commit run --all-files`
- `make test-workflows`
- repository-relative Markdown link target sweep
- stale uppercase-path sweep
- workflow, secret, YAML, shell, Dockerfile, and publishing-policy checks

The docs are tidier, safer, and just flamboyant enough to pass port forwarding. 🌈🚪